### PR TITLE
Add `ReflectRef::Opaque`

### DIFF
--- a/crates/mirror-mirror/src/get_field.rs
+++ b/crates/mirror-mirror/src/get_field.rs
@@ -47,6 +47,7 @@ impl<'a> GetField<'a, &str, private::Value> for &'a Value {
             | ReflectRef::Tuple(_)
             | ReflectRef::List(_)
             | ReflectRef::Array(_)
+            | ReflectRef::Opaque(_)
             | ReflectRef::Scalar(_) => None,
         }
     }
@@ -65,6 +66,7 @@ impl<'a> GetFieldMut<'a, &str, private::Value> for &'a mut Value {
             | ReflectMut::Tuple(_)
             | ReflectMut::List(_)
             | ReflectMut::Array(_)
+            | ReflectMut::Opaque(_)
             | ReflectMut::Scalar(_) => None,
         }
     }
@@ -86,7 +88,7 @@ where
                 ReflectRef::Array(inner) => inner.get_field(key),
                 ReflectRef::List(inner) => inner.get_field(key),
                 ReflectRef::Map(inner) => inner.get_field(key),
-                ReflectRef::Struct(_) | ReflectRef::Scalar(_) => None,
+                ReflectRef::Struct(_) | ReflectRef::Scalar(_) | ReflectRef::Opaque(_) => None,
             }
         } else if let Some(key) = key.as_any().downcast_ref::<String>() {
             match self.reflect_ref() {
@@ -97,6 +99,7 @@ where
                 | ReflectRef::Enum(_)
                 | ReflectRef::List(_)
                 | ReflectRef::Array(_)
+                | ReflectRef::Opaque(_)
                 | ReflectRef::Scalar(_) => None,
             }
         } else {
@@ -108,6 +111,7 @@ where
                 | ReflectRef::Array(_)
                 | ReflectRef::List(_)
                 | ReflectRef::Struct(_)
+                | ReflectRef::Opaque(_)
                 | ReflectRef::Scalar(_) => None,
             }
         }
@@ -130,7 +134,7 @@ where
                 ReflectMut::List(inner) => inner.get_field_mut(key),
                 ReflectMut::Array(inner) => inner.get_field_mut(key),
                 ReflectMut::Map(inner) => inner.get_field_mut(key),
-                ReflectMut::Struct(_) | ReflectMut::Scalar(_) => None,
+                ReflectMut::Struct(_) | ReflectMut::Scalar(_) | ReflectMut::Opaque(_) => None,
             }
         } else if let Some(key) = key.as_any().downcast_ref::<String>() {
             match self.reflect_mut() {
@@ -141,6 +145,7 @@ where
                 | ReflectMut::Enum(_)
                 | ReflectMut::List(_)
                 | ReflectMut::Array(_)
+                | ReflectMut::Opaque(_)
                 | ReflectMut::Scalar(_) => None,
             }
         } else {
@@ -152,6 +157,7 @@ where
                 | ReflectMut::List(_)
                 | ReflectMut::Array(_)
                 | ReflectMut::Struct(_)
+                | ReflectMut::Opaque(_)
                 | ReflectMut::Scalar(_) => None,
             }
         }

--- a/crates/mirror-mirror/src/key_path.rs
+++ b/crates/mirror-mirror/src/key_path.rs
@@ -49,6 +49,7 @@ where
                     | ReflectRef::Tuple(_)
                     | ReflectRef::List(_)
                     | ReflectRef::Array(_)
+                    | ReflectRef::Opaque(_)
                     | ReflectRef::Scalar(_) => return None,
                 },
                 Key::Element(index) => match value.reflect_ref() {
@@ -58,7 +59,9 @@ where
                     ReflectRef::List(inner) => inner.get(*index)?,
                     ReflectRef::Array(inner) => inner.get(*index)?,
                     ReflectRef::Map(inner) => inner.get(index)?,
-                    ReflectRef::Struct(_) | ReflectRef::Scalar(_) => return None,
+                    ReflectRef::Struct(_) | ReflectRef::Scalar(_) | ReflectRef::Opaque(_) => {
+                        return None
+                    }
                 },
                 Key::Variant(variant) => match value.reflect_ref() {
                     ReflectRef::Enum(enum_) => {
@@ -74,6 +77,7 @@ where
                     | ReflectRef::List(_)
                     | ReflectRef::Array(_)
                     | ReflectRef::Map(_)
+                    | ReflectRef::Opaque(_)
                     | ReflectRef::Scalar(_) => return None,
                 },
             };
@@ -110,6 +114,7 @@ where
                     | ReflectMut::Tuple(_)
                     | ReflectMut::List(_)
                     | ReflectMut::Array(_)
+                    | ReflectMut::Opaque(_)
                     | ReflectMut::Scalar(_) => return None,
                 },
                 Key::Element(index) => match value.reflect_mut() {
@@ -119,7 +124,9 @@ where
                     ReflectMut::List(inner) => inner.get_mut(*index)?,
                     ReflectMut::Array(inner) => inner.get_mut(*index)?,
                     ReflectMut::Map(inner) => inner.get_mut(index)?,
-                    ReflectMut::Struct(_) | ReflectMut::Scalar(_) => return None,
+                    ReflectMut::Struct(_) | ReflectMut::Scalar(_) | ReflectMut::Opaque(_) => {
+                        return None
+                    }
                 },
                 Key::Variant(variant) => match value.reflect_mut() {
                     ReflectMut::Enum(enum_) => {
@@ -135,6 +142,7 @@ where
                     | ReflectMut::List(_)
                     | ReflectMut::Array(_)
                     | ReflectMut::Map(_)
+                    | ReflectMut::Opaque(_)
                     | ReflectMut::Scalar(_) => return None,
                 },
             };

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -380,6 +380,9 @@ pub enum ReflectRef<'a> {
     List(&'a dyn List),
     Map(&'a dyn Map),
     Scalar(ScalarRef<'a>),
+    /// Not all `Reflect` implementations allow access to the underlying value. This variant can be
+    /// used for such types.
+    Opaque(&'a dyn Reflect),
 }
 
 impl<'a> ReflectRef<'a> {
@@ -438,6 +441,13 @@ impl<'a> ReflectRef<'a> {
             _ => None,
         }
     }
+
+    pub fn as_opaque(self) -> Option<&'a dyn Reflect> {
+        match self {
+            Self::Opaque(inner) => Some(inner),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -471,6 +481,9 @@ pub enum ReflectMut<'a> {
     List(&'a mut dyn List),
     Map(&'a mut dyn Map),
     Scalar(ScalarMut<'a>),
+    /// Not all `Reflect` implementations allow mutable access to the underlying value (such as
+    /// [`std::num::NonZeroU8`]). This variant can be used for such types.
+    Opaque(&'a mut dyn Reflect),
 }
 
 impl<'a> ReflectMut<'a> {
@@ -526,6 +539,13 @@ impl<'a> ReflectMut<'a> {
     pub fn as_scalar_mut(self) -> Option<ScalarMut<'a>> {
         match self {
             Self::Scalar(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_opaque_mut(self) -> Option<&'a mut dyn Reflect> {
+        match self {
+            Self::Opaque(inner) => Some(inner),
             _ => None,
         }
     }

--- a/crates/mirror-mirror/src/std_impls/mod.rs
+++ b/crates/mirror-mirror/src/std_impls/mod.rs
@@ -1,4 +1,5 @@
 mod array;
 mod btree_map;
+mod non_zero;
 mod option;
 mod vec;

--- a/crates/mirror-mirror/src/std_impls/non_zero.rs
+++ b/crates/mirror-mirror/src/std_impls/non_zero.rs
@@ -1,0 +1,106 @@
+use std::{
+    any::Any,
+    fmt,
+    num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+        NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    },
+};
+
+use crate::{
+    type_info::graph::{Id, TypeInfoGraph},
+    FromReflect, Reflect, ReflectMut, ReflectRef, ScalarRef, TypeInfoRoot, Typed, Value,
+};
+
+macro_rules! impl_traits {
+    ($($non_zero_ident:ident ($inner:ident)),* $(,)?) => {
+        $(
+            impl Reflect for $non_zero_ident {
+                fn type_info(&self) -> TypeInfoRoot {
+                    impl Typed for $non_zero_ident {
+                        fn build(graph: &mut TypeInfoGraph) -> Id {
+                            <$inner as Typed>::build(graph)
+                        }
+                    }
+                    <Self as Typed>::type_info()
+                }
+
+                fn as_any(&self) -> &dyn Any {
+                    self
+                }
+
+                fn as_any_mut(&mut self) -> &mut dyn Any {
+                    self
+                }
+
+                fn as_reflect(&self) -> &dyn Reflect {
+                    self
+                }
+
+                fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+                    self
+                }
+
+                fn reflect_ref(&self) -> ReflectRef<'_> {
+                    ReflectRef::Scalar(ScalarRef::$inner(self.get()))
+                }
+
+                fn reflect_mut(&mut self) -> ReflectMut<'_> {
+                    ReflectMut::Opaque(self)
+                }
+
+                fn patch(&mut self, value: &dyn Reflect) {
+                    if let Some(n) = Self::from_reflect(value) {
+                        *self = n;
+                    }
+                }
+
+                fn to_value(&self) -> Value {
+                    self.get().to_value()
+                }
+
+                fn clone_reflect(&self) -> Box<dyn Reflect> {
+                    Box::new(*self)
+                }
+
+                fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    if f.alternate() {
+                        write!(f, "{:#?}", self)
+                    } else {
+                        write!(f, "{:?}", self)
+                    }
+                }
+            }
+
+            impl FromReflect for $non_zero_ident {
+                fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+                    if let Some(n) = reflect.downcast_ref::<Self>() {
+                        Some(*n)
+                    } else {
+                        $inner::from_reflect(reflect).and_then(Self::new)
+                    }
+                }
+            }
+
+            impl From<$non_zero_ident> for Value {
+                fn from(n: $non_zero_ident) -> Self {
+                    n.to_value()
+                }
+            }
+        )*
+    };
+}
+
+impl_traits! {
+    NonZeroUsize(usize),
+    NonZeroU8(u8),
+    NonZeroU16(u16),
+    NonZeroU32(u32),
+    NonZeroU64(u64),
+    NonZeroU128(u128),
+    NonZeroI8(i8),
+    NonZeroI16(i16),
+    NonZeroI32(i32),
+    NonZeroI64(i64),
+    NonZeroI128(i128),
+}


### PR DESCRIPTION
Useful for types that don't expose the underlying value.