### PR TITLE
Make speedy support optional

### DIFF
--- a/crates/mirror-mirror-macros/src/derive_reflect/attrs.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/attrs.rs
@@ -23,7 +23,7 @@ mod kw {
     syn::custom_keyword!(crate_name);
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(super) struct ItemAttrs {
     pub(super) debug_opt_out: bool,
     pub(super) clone_opt_out: bool,
@@ -352,7 +352,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub(super) struct InnerAttrs {
     pub(super) skip: bool,
     pub(super) meta: HashMap<Ident, Expr>,

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -10,14 +10,14 @@ rust-version = "1.65"
 description = "Reflection library for Rust"
 keywords = ["reflection"]
 
+[features]
+default = ["speedy"]
+
 [dependencies]
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.0" }
 ordered-float = "3.4.0"
 serde = { version = "1.0", features = ["derive"] }
-speedy = "0.8"
-
-[dev-dependencies]
-serde_json = "1.0"
+speedy = { version = "0.8", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mirror-mirror/src/enum_.rs
+++ b/crates/mirror-mirror/src/enum_.rs
@@ -18,8 +18,6 @@ use crate::Typed;
 use crate::Value;
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 use std::any::Any;
 use std::fmt;
 
@@ -54,17 +52,15 @@ pub enum VariantKind {
     Unit,
 }
 
-#[derive(
-    Readable, Writable, Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd,
-)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct EnumValue {
     name: String,
     kind: EnumValueKind,
 }
 
-#[derive(
-    Readable, Writable, Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd,
-)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 enum EnumValueKind {
     Struct(StructValue),
     Tuple(TupleValue),

--- a/crates/mirror-mirror/src/key_path.rs
+++ b/crates/mirror-mirror/src/key_path.rs
@@ -2,8 +2,6 @@ use std::fmt;
 
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 
 use crate::Reflect;
 use crate::ReflectMut;
@@ -164,7 +162,8 @@ where
     }
 }
 
-#[derive(Readable, Writable, Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct KeyPath {
     pub(crate) path: Vec<Key>,
 }
@@ -215,7 +214,8 @@ mod private {
     impl Sealed for String {}
     impl Sealed for usize {}
 
-    #[derive(Readable, Writable, Serialize, Deserialize, Debug, Clone)]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
     pub enum Key {
         Field(String),
         Element(usize),

--- a/crates/mirror-mirror/src/struct_/struct_named.rs
+++ b/crates/mirror-mirror/src/struct_/struct_named.rs
@@ -12,8 +12,6 @@ use crate::Typed;
 use crate::Value;
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::fmt;
@@ -34,19 +32,8 @@ impl fmt::Debug for dyn Struct {
     }
 }
 
-#[derive(
-    Default,
-    Readable,
-    Writable,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct StructValue {
     // use a `BTreeMap` because `HashMap` isn't `Hash`
     fields: BTreeMap<String, Value>,

--- a/crates/mirror-mirror/src/struct_/tuple_struct.rs
+++ b/crates/mirror-mirror/src/struct_/tuple_struct.rs
@@ -14,8 +14,6 @@ use crate::Typed;
 use crate::Value;
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 use std::any::Any;
 use std::fmt;
 
@@ -35,19 +33,8 @@ impl fmt::Debug for dyn TupleStruct {
     }
 }
 
-#[derive(
-    Default,
-    Readable,
-    Writable,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TupleStructValue {
     tuple: TupleValue,
 }

--- a/crates/mirror-mirror/src/tests/struct_.rs
+++ b/crates/mirror-mirror/src/tests/struct_.rs
@@ -69,19 +69,6 @@ fn from_reflect() {
 }
 
 #[test]
-fn serialize_deserialize() {
-    let foo = Foo::default();
-    let struct_value = foo.to_value();
-
-    let json = serde_json::to_string(&struct_value).unwrap();
-
-    let struct_value = serde_json::from_str::<Value>(&json).unwrap();
-    let foo = Foo::from_reflect(&struct_value).unwrap();
-
-    assert_eq!(foo.field, 0);
-}
-
-#[test]
 fn fields() {
     let foo = Foo::default();
 

--- a/crates/mirror-mirror/src/tuple.rs
+++ b/crates/mirror-mirror/src/tuple.rs
@@ -14,8 +14,6 @@ use crate::Typed;
 use crate::Value;
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 use std::any::Any;
 use std::fmt;
 use std::fmt::Debug;
@@ -36,19 +34,8 @@ impl fmt::Debug for dyn Tuple {
     }
 }
 
-#[derive(
-    Default,
-    Readable,
-    Writable,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TupleValue {
     fields: Vec<Value>,
 }

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -9,20 +9,8 @@ use crate::Value;
 
 use super::*;
 
-#[derive(
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    Writable,
-    Readable,
-    Hash,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    Eq,
-    Debug,
-)]
+#[derive(Clone, Copy, Serialize, Deserialize, Hash, PartialEq, PartialOrd, Ord, Eq, Debug)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct Id(u64);
 
 impl Id {
@@ -36,7 +24,8 @@ impl Id {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TypeInfoGraph {
     pub(super) map: HashMap<Id, Option<TypeInfoNode>>,
 }
@@ -71,7 +60,8 @@ impl TypeInfoGraph {
 
 type Metadata = HashMap<String, Value>;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub enum TypeInfoNode {
     Struct(StructInfoNode),
     TupleStruct(TupleStructInfoNode),
@@ -104,7 +94,8 @@ impl_from! { Map(MapInfoNode) }
 impl_from! { Scalar(ScalarInfoNode) }
 impl_from! { Opaque(OpaqueInfoNode) }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct StructInfoNode {
     pub(super) type_name: String,
     pub(super) fields: Vec<NamedFieldNode>,
@@ -130,7 +121,8 @@ fn map_docs(docs: &[&'static str]) -> Box<[String]> {
     docs.iter().map(|s| (*s).to_owned()).collect()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TupleStructInfoNode {
     pub(super) type_name: String,
     pub(super) fields: Vec<UnnamedFieldNode>,
@@ -152,7 +144,8 @@ impl TupleStructInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct EnumInfoNode {
     pub(super) type_name: String,
     pub(super) variants: Vec<VariantNode>,
@@ -174,14 +167,16 @@ impl EnumInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub enum VariantNode {
     Struct(StructVariantInfoNode),
     Tuple(TupleVariantInfoNode),
     Unit(UnitVariantInfoNode),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct StructVariantInfoNode {
     pub(super) name: String,
     pub(super) fields: Vec<NamedFieldNode>,
@@ -205,7 +200,8 @@ impl StructVariantInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TupleVariantInfoNode {
     pub(super) name: String,
     pub(super) fields: Vec<UnnamedFieldNode>,
@@ -229,7 +225,8 @@ impl TupleVariantInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct UnitVariantInfoNode {
     pub(super) name: String,
     pub(super) metadata: Metadata,
@@ -246,7 +243,8 @@ impl UnitVariantInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TupleInfoNode {
     pub(super) type_name: String,
     pub(super) fields: Vec<UnnamedFieldNode>,
@@ -268,7 +266,8 @@ impl TupleInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct NamedFieldNode {
     pub(super) name: String,
     pub(super) id: Id,
@@ -295,7 +294,8 @@ impl NamedFieldNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct UnnamedFieldNode {
     pub(super) id: Id,
     pub(super) metadata: Metadata,
@@ -315,7 +315,8 @@ impl UnnamedFieldNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct ArrayInfoNode {
     pub(super) type_name: String,
     pub(super) field_type_id: Id,
@@ -336,7 +337,8 @@ impl ArrayInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct ListInfoNode {
     pub(super) type_name: String,
     pub(super) field_type_id: Id,
@@ -355,7 +357,8 @@ impl ListInfoNode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct MapInfoNode {
     pub(super) type_name: String,
     pub(super) key_type_id: Id,
@@ -379,7 +382,8 @@ impl MapInfoNode {
 
 #[derive(Debug, Clone)]
 #[allow(non_camel_case_types)]
-#[derive(Serialize, Deserialize, Writable, Readable)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub enum ScalarInfoNode {
     usize,
     u8,
@@ -418,7 +422,8 @@ scalar_typed! {
     bool char String
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct OpaqueInfoNode {
     pub(super) type_name: String,
     pub(super) metadata: Metadata,

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -2,8 +2,6 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 
 use graph::*;
 
@@ -32,7 +30,8 @@ pub trait GetTypedPath<'a> {
     fn at_typed(self, key_path: KeyPath) -> Option<TypeInfoAtPath<'a>>;
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub struct TypeInfoRoot {
     root: Id,
     graph: TypeInfoGraph,
@@ -422,7 +421,8 @@ impl<'a> GetMeta<'a> for OpaqueInfo<'a> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Writable, Readable)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub enum ScalarInfo {
     usize,
     u8,

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -16,15 +16,14 @@ use crate::Typed;
 use ordered_float::OrderedFloat;
 use serde::Deserialize;
 use serde::Serialize;
-use speedy::Readable;
-use speedy::Writable;
 use std::any::Any;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt;
 
 #[allow(non_camel_case_types)]
-#[derive(Readable, Writable, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 pub enum Value {
     usize(usize),
     u8(u8),


### PR DESCRIPTION
Puts speedy derives behind a feature flag, enabled by default. Required for `no_std` support since `speedy` doesn't support `no_std`.