### PR TITLE
Don't enable `std` feature when enabling `serde`

### DIFF
--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["reflection"]
 default = ["speedy", "serde", "std"]
 std = []
 speedy = ["std", "dep:speedy"]
-serde = ["std", "dep:serde"]
+serde = ["dep:serde"]
 
 [dependencies]
 ahash = { version = "0.8.2", default-features = false }


### PR DESCRIPTION
`serde` doesn't need `std` so we don't need to enable the `std` feature when using `serde`.