### PR TITLE
Use `FromReflect` for accessing meta data

### DIFF
--- a/crates/mirror-mirror/src/tests/mod.rs
+++ b/crates/mirror-mirror/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod meta;
 mod struct_;
 mod tuple;
 mod tuple_struct;
+mod type_info;
 mod value;
 
 #[derive(Reflect)]

--- a/crates/mirror-mirror/src/tests/type_info.rs
+++ b/crates/mirror-mirror/src/tests/type_info.rs
@@ -1,0 +1,78 @@
+use crate::type_info::*;
+use crate::Reflect;
+
+#[test]
+fn struct_() {
+    #[derive(Reflect, Clone, Debug)]
+    #[reflect(crate_name(crate))]
+    struct Foo {
+        n: i32,
+        foos: Vec<Foo>,
+    }
+
+    let type_info = <Foo as Typed>::type_info();
+
+    assert_eq!(
+        type_info.get_type().type_name(),
+        "mirror_mirror::tests::type_info::struct_::Foo"
+    );
+
+    let struct_ = type_info.get_type().as_struct().unwrap();
+
+    assert_eq!(
+        struct_.type_name(),
+        "mirror_mirror::tests::type_info::struct_::Foo"
+    );
+
+    for field in struct_.field_types() {
+        match field.name() {
+            "foos" => {
+                assert_eq!(
+                    field.get_type().type_name(),
+                    "alloc::vec::Vec<mirror_mirror::tests::type_info::struct_::Foo>"
+                );
+
+                let list = field.get_type().as_list().unwrap();
+
+                assert_eq!(
+                    list.type_name(),
+                    "alloc::vec::Vec<mirror_mirror::tests::type_info::struct_::Foo>"
+                );
+
+                assert_eq!(
+                    list.element_type().type_name(),
+                    "mirror_mirror::tests::type_info::struct_::Foo"
+                );
+            }
+            "n" => {
+                assert_eq!(field.get_type().type_name(), "i32");
+                let scalar = field.get_type().as_scalar().unwrap();
+                assert_eq!(scalar.type_name(), "i32");
+            }
+            _ => panic!("wat"),
+        }
+    }
+}
+
+#[test]
+fn enum_() {
+    #[derive(Reflect, Clone, Debug)]
+    #[reflect(crate_name(crate))]
+    enum Foo {
+        A { a: String },
+        B(Vec<Foo>),
+        C,
+    }
+}
+
+#[test]
+fn complex_meta_type() {
+    #[derive(Reflect, Clone, Debug, PartialEq, Eq)]
+    #[reflect(crate_name(crate), meta(a = Foo(1337)))]
+    struct Foo(i32);
+
+    let type_info = <Foo as Typed>::type_info();
+
+    let foo = type_info.get_type().get_meta::<Foo>("a").unwrap();
+    assert_eq!(foo, Foo(1337));
+}

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -16,6 +16,7 @@ use crate::key_path::KeyPath;
 use crate::struct_::StructValue;
 use crate::tuple::TupleValue;
 use crate::tuple_struct::TupleStructValue;
+use crate::FromReflect;
 use crate::Reflect;
 use crate::Value;
 
@@ -408,12 +409,12 @@ mod private {
 pub trait GetMeta<'a>: private::Sealed {
     fn meta(self, key: &str) -> Option<&'a dyn Reflect>;
 
-    fn get_meta<T>(self, key: &str) -> Option<&'a T>
+    fn get_meta<T>(self, key: &str) -> Option<T>
     where
-        T: Reflect,
+        T: FromReflect,
         Self: Sized,
     {
-        self.meta(key)?.downcast_ref()
+        T::from_reflect(self.meta(key)?)
     }
 
     fn docs(self) -> &'a [String];
@@ -1231,75 +1232,5 @@ impl<'a> GetTypePath<'a> for TypeAtPath<'a> {
         }
 
         go(self, key_path.path.iter().peekable())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::Reflect;
-
-    #[test]
-    fn struct_() {
-        #[derive(Reflect, Clone, Debug)]
-        #[reflect(crate_name(crate))]
-        struct Foo {
-            n: i32,
-            foos: Vec<Foo>,
-        }
-
-        let type_info = <Foo as Typed>::type_info();
-
-        assert_eq!(
-            type_info.get_type().type_name(),
-            "mirror_mirror::type_info::tests::struct_::Foo"
-        );
-
-        let struct_ = type_info.get_type().as_struct().unwrap();
-
-        assert_eq!(
-            struct_.type_name(),
-            "mirror_mirror::type_info::tests::struct_::Foo"
-        );
-
-        for field in struct_.field_types() {
-            match field.name() {
-                "foos" => {
-                    assert_eq!(
-                        field.get_type().type_name(),
-                        "alloc::vec::Vec<mirror_mirror::type_info::tests::struct_::Foo>"
-                    );
-
-                    let list = field.get_type().as_list().unwrap();
-
-                    assert_eq!(
-                        list.type_name(),
-                        "alloc::vec::Vec<mirror_mirror::type_info::tests::struct_::Foo>"
-                    );
-
-                    assert_eq!(
-                        list.element_type().type_name(),
-                        "mirror_mirror::type_info::tests::struct_::Foo"
-                    );
-                }
-                "n" => {
-                    assert_eq!(field.get_type().type_name(), "i32");
-                    let scalar = field.get_type().as_scalar().unwrap();
-                    assert_eq!(scalar.type_name(), "i32");
-                }
-                _ => panic!("wat"),
-            }
-        }
-    }
-
-    #[test]
-    fn enum_() {
-        #[derive(Reflect, Clone, Debug)]
-        #[reflect(crate_name(crate))]
-        enum Foo {
-            A { a: String },
-            B(Vec<Foo>),
-            C,
-        }
     }
 }


### PR DESCRIPTION
Since metadata values are stored as `Value` we cannot use `downcast_ref`. That only works for scalar types.