### PR TITLE
Make type descriptors `'static`

### DIFF
--- a/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
@@ -265,8 +265,10 @@ fn expand_reflect(
         } = generics;
 
         quote! {
-            fn type_descriptor(&self) -> TypeDescriptor {
+            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 impl #impl_generics Typed for #ident #type_generics #where_clause {
+                    fn_type_descriptor!();
+
                     fn build(graph: &mut TypeGraph) -> NodeId {
                         let variants = &[#(#code_for_variants),*];
                         graph.get_or_build_node_with::<Self, _>(|graph| {

--- a/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
@@ -111,8 +111,10 @@ fn expand_reflect(
         } = generics;
 
         quote! {
-            fn type_descriptor(&self) -> TypeDescriptor {
+            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 impl #impl_generics Typed for #ident #type_generics #where_clause {
+                    fn_type_descriptor!();
+
                     fn build(graph: &mut TypeGraph) -> NodeId {
                         graph.get_or_build_node_with::<Self, _>(|graph| {
                             let fields = &[#(#code_for_fields),*];

--- a/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
@@ -113,8 +113,10 @@ fn expand_reflect(
         } = generics;
 
         quote! {
-            fn type_descriptor(&self) -> TypeDescriptor {
+            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 impl #impl_generics Typed for #ident #type_generics #where_clause {
+                    fn_type_descriptor!();
+
                     fn build(graph: &mut TypeGraph) -> NodeId {
                         let fields = &[#(#code_for_fields),*];
                         graph.get_or_build_node_with::<Self, _>(|graph| {

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -19,6 +19,7 @@ serde = ["dep:serde"]
 [dependencies]
 ahash = { version = "0.8.2", default-features = false }
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.0" }
+once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
 ordered-float = { version = "3.4.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 speedy = { version = "0.8", optional = true }

--- a/crates/mirror-mirror/src/enum_.rs
+++ b/crates/mirror-mirror/src/enum_.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -183,8 +184,10 @@ impl TupleVariantBuilder {
 }
 
 impl Reflect for EnumValue {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for EnumValue {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -307,7 +307,6 @@ macro_rules! fn_type_descriptor {
             {
                 // required for generic types to have different type descriptors
                 // such as `Vec<i32>` and `Vec<bool>`
-                use once_cell::race::OnceBox;
                 use std::collections::HashMap;
                 use std::sync::RwLock;
                 use $crate::__private::*;
@@ -1156,7 +1155,7 @@ pub mod __private {
     pub use core::any::TypeId;
     pub use core::fmt;
 
-    pub use once_cell;
+    pub use once_cell::race::OnceBox;
 
     pub use self::enum_::*;
     pub use self::key_path::*;

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -310,8 +310,7 @@ macro_rules! fn_type_descriptor {
 
             // a map required for generic types to have different type descriptors such as
             // `Vec<i32>` and `Vec<bool>`
-            static INFO: OnceBox<RwLock<HashMap<TypeId, &'static TypeDescriptor>>> =
-                OnceBox::new();
+            static INFO: OnceBox<RwLock<HashMap<TypeId, &'static TypeDescriptor>>> = OnceBox::new();
 
             let type_id = TypeId::of::<Self>();
 

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -299,46 +299,49 @@ macro_rules! trivial_reflect_methods {
     };
 }
 
+#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! fn_type_descriptor {
     () => {
         fn type_descriptor() -> $crate::__private::Cow<'static, $crate::type_info::TypeDescriptor> {
-            #[cfg(feature = "std")]
-            {
-                // required for generic types to have different type descriptors
-                // such as `Vec<i32>` and `Vec<bool>`
-                use std::collections::HashMap;
-                use std::sync::RwLock;
-                use $crate::__private::*;
+            use std::collections::HashMap;
+            use std::sync::RwLock;
+            use $crate::__private::*;
 
-                static INFO: OnceBox<RwLock<HashMap<TypeId, &'static TypeDescriptor>>> =
-                    OnceBox::new();
+            // a map required for generic types to have different type descriptors such as
+            // `Vec<i32>` and `Vec<bool>`
+            static INFO: OnceBox<RwLock<HashMap<TypeId, &'static TypeDescriptor>>> =
+                OnceBox::new();
 
-                let type_id = TypeId::of::<Self>();
+            let type_id = TypeId::of::<Self>();
 
-                let lock = INFO.get_or_init(Box::default);
-                if let Some(info) = lock.read().unwrap().get(&type_id) {
-                    return Cow::Borrowed(info);
-                }
-
-                let mut map = lock.write().unwrap();
-                let info = map.entry(type_id).or_insert_with(|| {
-                    let mut graph = TypeGraph::default();
-                    let id = Self::build(&mut graph);
-                    let info = TypeDescriptor::__private_new(id, graph);
-                    Box::leak(Box::new(info))
-                });
-                Cow::Borrowed(*info)
+            let lock = INFO.get_or_init(Box::default);
+            if let Some(info) = lock.read().unwrap().get(&type_id) {
+                return Cow::Borrowed(info);
             }
 
-            #[cfg(not(feature = "std"))]
-            {
-                use $crate::__private::*;
-
+            let mut map = lock.write().unwrap();
+            let info = map.entry(type_id).or_insert_with(|| {
                 let mut graph = TypeGraph::default();
                 let id = Self::build(&mut graph);
-                Cow::Owned(TypeDescriptor::__private_new(id, graph))
-            }
+                let info = TypeDescriptor::__private_new(id, graph);
+                Box::leak(Box::new(info))
+            });
+            Cow::Borrowed(*info)
+        }
+    };
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! fn_type_descriptor {
+    () => {
+        fn type_descriptor() -> $crate::__private::Cow<'static, $crate::type_info::TypeDescriptor> {
+            use $crate::__private::*;
+
+            let mut graph = TypeGraph::default();
+            let id = Self::build(&mut graph);
+            Cow::Owned(TypeDescriptor::__private_new(id, graph))
         }
     };
 }

--- a/crates/mirror-mirror/src/std_impls/array.rs
+++ b/crates/mirror-mirror/src/std_impls/array.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::any::Any;
@@ -21,11 +22,13 @@ impl<T, const N: usize> Reflect for [T; N]
 where
     T: FromReflect + Typed,
 {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl<T, const N: usize> Typed for [T; N]
         where
             T: Typed,
         {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| ArrayNode::new::<Self, T, N>(graph))
             }

--- a/crates/mirror-mirror/src/std_impls/boxed.rs
+++ b/crates/mirror-mirror/src/std_impls/boxed.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::fmt;
@@ -18,11 +19,13 @@ impl<T> Reflect for Box<T>
 where
     T: Reflect + Typed,
 {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl<T> Typed for Box<T>
         where
             T: Typed,
         {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 T::build(graph)
             }

--- a/crates/mirror-mirror/src/std_impls/btree_map.rs
+++ b/crates/mirror-mirror/src/std_impls/btree_map.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use core::any::Any;
@@ -75,12 +76,14 @@ where
     K: FromReflect + Typed + Ord,
     V: FromReflect + Typed,
 {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl<K, V> Typed for BTreeMap<K, V>
         where
             K: Typed,
             V: Typed,
         {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| MapNode::new::<Self, K, V>(graph))
             }

--- a/crates/mirror-mirror/src/std_impls/vec.rs
+++ b/crates/mirror-mirror/src/std_impls/vec.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::any::Any;
@@ -81,11 +82,13 @@ impl<T> Reflect for Vec<T>
 where
     T: FromReflect + Typed,
 {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl<T> Typed for Vec<T>
         where
             T: Typed,
         {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| ListNode::new::<Self, T>(graph))
             }

--- a/crates/mirror-mirror/src/std_impls/via_scalar.rs
+++ b/crates/mirror-mirror/src/std_impls/via_scalar.rs
@@ -17,8 +17,10 @@ macro_rules! impl_reflect_via_scalar {
             use $crate::__private::*;
 
             impl Reflect for $ty {
-                fn type_descriptor(&self) -> TypeDescriptor {
+                fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                     impl Typed for $ty {
+                        fn_type_descriptor!();
+
                         fn build(graph: &mut TypeGraph) -> NodeId {
                             graph.get_or_build_node_with::<Self, _>(|graph| {
                                 OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/struct_.rs
+++ b/crates/mirror-mirror/src/struct_.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -72,8 +73,10 @@ impl StructValue {
 }
 
 impl Reflect for StructValue {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for StructValue {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/tests/type_info.rs
+++ b/crates/mirror-mirror/src/tests/type_info.rs
@@ -1,6 +1,7 @@
 use core::any::type_name;
 
 use crate::type_info::*;
+use crate::FromReflect;
 use crate::Reflect;
 
 #[test]
@@ -96,6 +97,74 @@ fn type_to_root() {
         .get_type()
         .as_tuple_struct()
         .unwrap()
-        .to_type_root();
+        .into_type_descriptor();
     assert_eq!(type_info.get_type().type_name(), type_name::<Foo>());
+}
+
+#[test]
+fn two_types() {
+    #[derive(Reflect, Clone, Debug, PartialEq, Eq)]
+    #[reflect(crate_name(crate))]
+    struct Foo(i32);
+
+    #[derive(Reflect, Clone, Debug, PartialEq, Eq)]
+    #[reflect(crate_name(crate))]
+    struct Bar(bool);
+
+    assert_eq!(
+        <Foo as Typed>::type_descriptor()
+            .as_tuple_struct()
+            .unwrap()
+            .field_type_at(0)
+            .unwrap()
+            .get_type()
+            .as_scalar()
+            .unwrap(),
+        ScalarType::i32,
+    );
+
+    assert_eq!(
+        <Bar as Typed>::type_descriptor()
+            .as_tuple_struct()
+            .unwrap()
+            .field_type_at(0)
+            .unwrap()
+            .get_type()
+            .as_scalar()
+            .unwrap(),
+        ScalarType::bool,
+    )
+}
+
+#[test]
+fn how_to_handle_generics() {
+    #[derive(Reflect, Clone, Debug, PartialEq, Eq)]
+    #[reflect(crate_name(crate), opt_out(Debug, Clone))]
+    struct Foo<T>(T)
+    where
+        T: Reflect + FromReflect + Typed;
+
+    assert_eq!(
+        <Foo<i32> as Typed>::type_descriptor()
+            .as_tuple_struct()
+            .unwrap()
+            .field_type_at(0)
+            .unwrap()
+            .get_type()
+            .as_scalar()
+            .unwrap(),
+        ScalarType::i32,
+    );
+
+    assert_eq!(
+        <Foo<bool> as Typed>::type_descriptor()
+            .as_tuple_struct()
+            .unwrap()
+            .field_type_at(0)
+            .unwrap()
+            .get_type()
+            .as_scalar()
+            .unwrap(),
+        ScalarType::bool,
+    );
 }

--- a/crates/mirror-mirror/src/tuple.rs
+++ b/crates/mirror-mirror/src/tuple.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::any::Any;
@@ -84,8 +85,10 @@ impl Tuple for TupleValue {
 }
 
 impl Reflect for TupleValue {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for TupleValue {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)
@@ -155,6 +158,8 @@ macro_rules! impl_tuple {
         where
             $($ident: Reflect + Typed + Clone,)*
         {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     let fields = &[
@@ -172,7 +177,7 @@ macro_rules! impl_tuple {
         where
             $($ident: Reflect + Typed + Clone,)*
         {
-            fn type_descriptor(&self) -> TypeDescriptor {
+            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 <Self as Typed>::type_descriptor()
             }
 

--- a/crates/mirror-mirror/src/tuple_struct.rs
+++ b/crates/mirror-mirror/src/tuple_struct.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::fmt;
@@ -62,8 +63,10 @@ impl TupleStructValue {
 }
 
 impl Reflect for TupleStructValue {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for TupleStructValue {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -486,6 +486,8 @@ macro_rules! scalar_typed {
     ($($ty:ident)*) => {
         $(
             impl Typed for $ty {
+                fn_type_descriptor!();
+
                 fn build(graph: &mut TypeGraph) -> NodeId {
                     graph.get_or_build_node_with::<Self, _>(|_graph| ScalarNode::$ty)
                 }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
@@ -171,8 +172,10 @@ macro_rules! for_each_variant {
 }
 
 impl Reflect for Value {
-    fn type_descriptor(&self) -> TypeDescriptor {
+    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for Value {
+            fn_type_descriptor!();
+
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)


### PR DESCRIPTION
This way you don't allocate a new type info for each call.