### PR TITLE
Add `SimpleTypeName`

### DIFF
--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"]
 ordered-float = { version = "3.4.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 speedy = { version = "0.8", optional = true }
+syn = { version = "1.0", default-features = false, features = ["full", "parsing"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mirror-mirror/src/tests/mod.rs
+++ b/crates/mirror-mirror/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod key_path;
 mod list;
 mod map;
 mod meta;
+mod simple_type_name;
 mod struct_;
 mod tuple;
 mod tuple_struct;

--- a/crates/mirror-mirror/src/tests/simple_type_name.rs
+++ b/crates/mirror-mirror/src/tests/simple_type_name.rs
@@ -1,0 +1,40 @@
+use alloc::collections::BTreeMap;
+
+use crate::type_info::SimpleTypeName;
+
+fn simple_type_name<T>() -> String {
+    SimpleTypeName::new_from_type::<T>().to_string()
+}
+
+#[test]
+fn works() {
+    struct Foo<'a, const N: usize>(&'a ());
+
+    assert_eq!(simple_type_name::<String>(), "String");
+    assert_eq!(simple_type_name::<i32>(), "i32");
+    assert_eq!(simple_type_name::<bool>(), "bool");
+    assert_eq!(simple_type_name::<()>(), "()");
+    assert_eq!(simple_type_name::<(i32,)>(), "(i32,)");
+    assert_eq!(simple_type_name::<(i32, String)>(), "(i32, String)");
+    assert_eq!(simple_type_name::<Vec<i32>>(), "Vec<i32>");
+    assert_eq!(simple_type_name::<Vec<&()>>(), "Vec<&()>");
+    assert_eq!(simple_type_name::<Vec<&mut ()>>(), "Vec<&mut ()>");
+    assert_eq!(simple_type_name::<Vec<&'static ()>>(), "Vec<&()>");
+    assert_eq!(simple_type_name::<Vec<&'static mut ()>>(), "Vec<&mut ()>");
+    assert_eq!(simple_type_name::<Option<String>>(), "Option<String>");
+    assert_eq!(
+        simple_type_name::<BTreeMap<i32, String>>(),
+        "BTreeMap<i32, String>"
+    );
+    assert_eq!(
+        simple_type_name::<BTreeMap<Vec<(i32, Option<bool>)>, String>>(),
+        "BTreeMap<Vec<(i32, Option<bool>)>, String>"
+    );
+    assert_eq!(simple_type_name::<[i32; 10]>(), "[i32; 10]");
+    assert_eq!(
+        simple_type_name::<[BTreeMap<i32, i32>; 10]>(),
+        "[BTreeMap<i32, i32>; 10]"
+    );
+    // type names don't include lifetimes
+    assert_eq!(simple_type_name::<Foo<'static, 10>>(), "Foo<10>");
+}

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -23,6 +23,10 @@ use crate::Value;
 
 pub mod graph;
 
+mod simple_type_name;
+
+pub use self::simple_type_name::SimpleTypeName;
+
 /// Trait for accessing type information.
 ///
 /// Will be implemented by `#[derive(Reflect)]`.

--- a/crates/mirror-mirror/src/type_info/simple_type_name.rs
+++ b/crates/mirror-mirror/src/type_info/simple_type_name.rs
@@ -1,0 +1,361 @@
+use core::{any::type_name, fmt};
+
+use syn::{
+    token::Mut, AngleBracketedGenericArguments, Expr, ExprLit, GenericArgument, Ident, Lit,
+    LitBool, LitFloat, LitInt, Path, PathArguments, PathSegment, Type, TypeArray, TypePath,
+    TypeReference, TypeTuple,
+};
+
+/// A writer for simplified type names.
+///
+/// By default type names are fully qualified which sometimes isn't desired. This type can be used
+/// to print the types names in a simplified form:
+///
+/// ```
+/// use core::any::type_name;
+/// use mirror_mirror::type_info::SimpleTypeName;
+///
+/// // the default, fully qualified type name
+/// assert_eq!(
+///     type_name::<Option<String>>(),
+///     "core::option::Option<alloc::string::String>",
+/// );
+///
+/// // the simplified type name which is less verbose
+/// assert_eq!(
+///     SimpleTypeName::new_from_type::<Option<String>>().to_string(),
+///     "Option<String>",
+/// );
+/// ```
+///
+/// # Not all types are supported
+///
+/// `SimpleTypeName` doesn't support printing absolutely all Rust types. It supports the most
+/// common ones but exotic types like function pointers or trait objects are not supported. Such
+/// types don't implement [`Typed`](super::Typed) anyway and are unlikely to show up when using
+/// `mirror-mirror`.
+///
+/// Thus be careful when calling `to_string()` or using `format!()` as those will panic on
+/// unsupported types:
+///
+/// ```should_panic
+/// use mirror_mirror::type_info::SimpleTypeName;
+///
+/// format!("{}", SimpleTypeName::new_from_type::<fn() -> i32>());
+/// ```
+///
+/// Instead use `write!` which allows handling the error
+///
+/// ```
+/// use mirror_mirror::type_info::SimpleTypeName;
+/// use core::fmt::Write;
+///
+/// let mut buf = String::new();
+/// match write!(&mut buf, "{}", SimpleTypeName::new_from_type::<fn() -> i32>()) {
+///     Ok(_) => {
+///         // all good
+///         # unreachable!();
+///     }
+///     Err(_) => {
+///         // unsupported type
+///         //
+///         // instead just write the type we get directly from the compiler
+///         buf.clear();
+///         write!(&mut buf, "{}", core::any::type_name::<fn() -> i32>()).unwrap();
+///         # assert_eq!(buf, "fn() -> i32");
+///     }
+/// }
+/// ```
+///
+/// If you need a type that isn't supported feel free to submit a pull request!
+#[allow(missing_debug_implementations)]
+pub struct SimpleTypeName {
+    ty: Type,
+}
+
+impl SimpleTypeName {
+    pub fn new(type_name: &str) -> Option<Self> {
+        let ty = syn::parse_str::<Type>(type_name).ok()?;
+        Some(Self { ty })
+    }
+
+    pub fn new_from_type<T>() -> Self {
+        Self::new(type_name::<T>()).expect("failed to parse type name")
+    }
+}
+
+impl fmt::Display for SimpleTypeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        TypeWriter { f }.write(&self.ty)
+    }
+}
+
+trait WriteAst<T> {
+    fn write(&mut self, ty: &T) -> fmt::Result;
+}
+
+struct TypeWriter<'a, 'b> {
+    f: &'a mut fmt::Formatter<'b>,
+}
+
+#[allow(clippy::wildcard_in_or_patterns)]
+impl<'a, 'b> WriteAst<Type> for TypeWriter<'a, 'b> {
+    fn write(&mut self, ty: &Type) -> fmt::Result {
+        match ty {
+            Type::Array(inner) => self.write(inner),
+            Type::Path(inner) => self.write(inner),
+            Type::Tuple(inner) => self.write(inner),
+            Type::Reference(inner) => self.write(inner),
+            Type::BareFn(_)
+            | Type::Group(_)
+            | Type::ImplTrait(_)
+            | Type::Infer(_)
+            | Type::Macro(_)
+            | Type::Never(_)
+            | Type::Paren(_)
+            | Type::Ptr(_)
+            | Type::Slice(_)
+            | Type::TraitObject(_)
+            | Type::Verbatim(_)
+            | _ => Err(fmt::Error),
+        }
+    }
+}
+
+impl<'a, 'b> WriteAst<TypeArray> for TypeWriter<'a, 'b> {
+    fn write(&mut self, array: &TypeArray) -> fmt::Result {
+        let TypeArray {
+            bracket_token: _,
+            elem,
+            semi_token: _,
+            len,
+        } = array;
+        write!(self.f, "[")?;
+        self.write(&**elem)?;
+        write!(self.f, "; ")?;
+        self.write(len)?;
+        write!(self.f, "]")?;
+        Ok(())
+    }
+}
+
+#[allow(clippy::wildcard_in_or_patterns)]
+impl<'a, 'b> WriteAst<Expr> for TypeWriter<'a, 'b> {
+    fn write(&mut self, expr: &Expr) -> fmt::Result {
+        match expr {
+            Expr::Lit(inner) => self.write(inner),
+            Expr::Array(_)
+            | Expr::Assign(_)
+            | Expr::AssignOp(_)
+            | Expr::Async(_)
+            | Expr::Await(_)
+            | Expr::Binary(_)
+            | Expr::Block(_)
+            | Expr::Box(_)
+            | Expr::Break(_)
+            | Expr::Call(_)
+            | Expr::Cast(_)
+            | Expr::Closure(_)
+            | Expr::Continue(_)
+            | Expr::Field(_)
+            | Expr::ForLoop(_)
+            | Expr::Group(_)
+            | Expr::If(_)
+            | Expr::Index(_)
+            | Expr::Let(_)
+            | Expr::Loop(_)
+            | Expr::Macro(_)
+            | Expr::Match(_)
+            | Expr::MethodCall(_)
+            | Expr::Paren(_)
+            | Expr::Path(_)
+            | Expr::Range(_)
+            | Expr::Reference(_)
+            | Expr::Repeat(_)
+            | Expr::Return(_)
+            | Expr::Struct(_)
+            | Expr::Try(_)
+            | Expr::TryBlock(_)
+            | Expr::Tuple(_)
+            | Expr::Type(_)
+            | Expr::Unary(_)
+            | Expr::Unsafe(_)
+            | Expr::Verbatim(_)
+            | Expr::While(_)
+            | Expr::Yield(_)
+            | _ => Err(fmt::Error),
+        }
+    }
+}
+
+impl<'a, 'b> WriteAst<ExprLit> for TypeWriter<'a, 'b> {
+    fn write(&mut self, lit: &ExprLit) -> fmt::Result {
+        let ExprLit { attrs: _, lit } = lit;
+        self.write(lit)?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<Lit> for TypeWriter<'a, 'b> {
+    fn write(&mut self, lit: &Lit) -> fmt::Result {
+        match lit {
+            Lit::Int(inner) => self.write(inner),
+            Lit::Bool(inner) => self.write(inner),
+            Lit::Float(inner) => self.write(inner),
+            Lit::Str(_) | Lit::ByteStr(_) | Lit::Byte(_) | Lit::Char(_) | Lit::Verbatim(_) => {
+                Err(fmt::Error)
+            }
+        }
+    }
+}
+
+impl<'a, 'b> WriteAst<LitInt> for TypeWriter<'a, 'b> {
+    fn write(&mut self, lit: &LitInt) -> fmt::Result {
+        write!(self.f, "{lit}")
+    }
+}
+
+impl<'a, 'b> WriteAst<LitFloat> for TypeWriter<'a, 'b> {
+    fn write(&mut self, lit: &LitFloat) -> fmt::Result {
+        write!(self.f, "{lit}")
+    }
+}
+
+impl<'a, 'b> WriteAst<LitBool> for TypeWriter<'a, 'b> {
+    fn write(&mut self, lit: &LitBool) -> fmt::Result {
+        write!(self.f, "{}", lit.value)
+    }
+}
+
+impl<'a, 'b> WriteAst<TypePath> for TypeWriter<'a, 'b> {
+    fn write(&mut self, ty: &TypePath) -> fmt::Result {
+        let TypePath { qself, path } = ty;
+        if qself.is_some() {
+            return Err(fmt::Error);
+        }
+        self.write(path)?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<Path> for TypeWriter<'a, 'b> {
+    fn write(&mut self, path: &Path) -> fmt::Result {
+        let Path {
+            leading_colon: _,
+            segments,
+        } = path;
+        let last = segments.last().ok_or(fmt::Error)?;
+        self.write(last)?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<PathSegment> for TypeWriter<'a, 'b> {
+    fn write(&mut self, path_segment: &PathSegment) -> fmt::Result {
+        let PathSegment { ident, arguments } = path_segment;
+        self.write(ident)?;
+        self.write(arguments)?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<Ident> for TypeWriter<'a, 'b> {
+    fn write(&mut self, ident: &Ident) -> fmt::Result {
+        write!(self.f, "{ident}")?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<PathArguments> for TypeWriter<'a, 'b> {
+    fn write(&mut self, args: &PathArguments) -> fmt::Result {
+        match args {
+            PathArguments::None => Ok(()),
+            PathArguments::AngleBracketed(inner) => self.write(inner),
+            PathArguments::Parenthesized(_) => Err(fmt::Error),
+        }
+    }
+}
+
+impl<'a, 'b> WriteAst<AngleBracketedGenericArguments> for TypeWriter<'a, 'b> {
+    fn write(&mut self, args: &AngleBracketedGenericArguments) -> fmt::Result {
+        let AngleBracketedGenericArguments {
+            colon2_token: _,
+            lt_token: _,
+            args,
+            gt_token: _,
+        } = args;
+        write!(self.f, "<")?;
+        let mut args = args.iter().peekable();
+        while let Some(arg) = args.next() {
+            self.write(arg)?;
+            if args.peek().is_some() {
+                write!(self.f, ", ")?;
+            }
+        }
+        write!(self.f, ">")?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<GenericArgument> for TypeWriter<'a, 'b> {
+    fn write(&mut self, arg: &GenericArgument) -> fmt::Result {
+        match arg {
+            GenericArgument::Type(inner) => self.write(inner),
+            GenericArgument::Const(inner) => self.write(inner),
+            GenericArgument::Lifetime(_)
+            | GenericArgument::Binding(_)
+            | GenericArgument::Constraint(_) => Err(fmt::Error),
+        }
+    }
+}
+
+impl<'a, 'b> WriteAst<TypeTuple> for TypeWriter<'a, 'b> {
+    fn write(&mut self, ty: &TypeTuple) -> fmt::Result {
+        let TypeTuple {
+            paren_token: _,
+            elems,
+        } = ty;
+        write!(self.f, "(")?;
+        if elems.len() == 1 {
+            for elem in elems {
+                self.write(elem)?;
+                write!(self.f, ",")?;
+            }
+        } else {
+            let mut elems = elems.iter().peekable();
+            while let Some(elem) = elems.next() {
+                self.write(elem)?;
+                if elems.peek().is_some() {
+                    write!(self.f, ", ")?;
+                }
+            }
+        }
+        write!(self.f, ")")?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<TypeReference> for TypeWriter<'a, 'b> {
+    fn write(&mut self, ty_ref: &TypeReference) -> fmt::Result {
+        let TypeReference {
+            and_token: _,
+            // type names don't include lifetimes
+            lifetime: _,
+            mutability,
+            elem,
+        } = ty_ref;
+        write!(self.f, "&")?;
+        if let Some(mutability) = mutability {
+            self.write(mutability)?;
+            write!(self.f, " ")?;
+        }
+        self.write(&**elem)?;
+        Ok(())
+    }
+}
+
+impl<'a, 'b> WriteAst<Mut> for TypeWriter<'a, 'b> {
+    fn write(&mut self, _: &Mut) -> fmt::Result {
+        write!(self.f, "mut")
+    }
+}


### PR DESCRIPTION
For writing type names less verbosely.