### PR TITLE
Remove unused `into_any` / `into_reflect` trait methods

### DIFF
--- a/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
@@ -293,10 +293,6 @@ fn expand_reflect(
 
     Ok(quote! {
         impl #impl_generics Reflect for #ident #type_generics #where_clause {
-            fn into_any(self: Box<Self>) -> Box<dyn Any> {
-                self
-            }
-
             fn as_any(&self) -> &dyn Any {
                 self
             }

--- a/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
@@ -301,10 +301,6 @@ fn expand_reflect(
                 self
             }
 
-            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-                self
-            }
-
             fn as_reflect(&self) -> &dyn Reflect {
                 self
             }

--- a/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
@@ -147,10 +147,6 @@ fn expand_reflect(
                 self
             }
 
-            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-                self
-            }
-
             fn as_reflect(&self) -> &dyn Reflect {
                 self
             }

--- a/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
@@ -139,10 +139,6 @@ fn expand_reflect(
 
     quote! {
         impl #impl_generics Reflect for #ident #type_generics #where_clause {
-            fn into_any(self: Box<Self>) -> Box<dyn Any> {
-                self
-            }
-
             fn as_any(&self) -> &dyn Any {
                 self
             }

--- a/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
@@ -148,10 +148,6 @@ fn expand_reflect(
                 self
             }
 
-            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-                self
-            }
-
             fn as_reflect(&self) -> &dyn Reflect {
                 self
             }

--- a/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
@@ -140,10 +140,6 @@ fn expand_reflect(
 
     quote! {
         impl #impl_generics Reflect for #ident #type_generics #where_clause {
-            fn into_any(self: Box<Self>) -> Box<dyn Any> {
-                self
-            }
-
             fn as_any(&self) -> &dyn Any {
                 self
             }

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -281,10 +281,6 @@ macro_rules! trivial_reflect_methods {
             self
         }
 
-        fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-            self
-        }
-
         fn as_reflect(&self) -> &dyn Reflect {
             self
         }
@@ -418,8 +414,6 @@ pub trait Reflect: Any + Send + 'static {
     fn as_any(&self) -> &dyn Any;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect>;
 
     fn as_reflect(&self) -> &dyn Reflect;
 
@@ -745,20 +739,6 @@ pub enum ReflectOwned {
 }
 
 impl ReflectOwned {
-    pub fn into_reflect(self) -> Box<dyn Reflect> {
-        match self {
-            Self::Struct(inner) => inner.into_reflect(),
-            Self::TupleStruct(inner) => inner.into_reflect(),
-            Self::Tuple(inner) => inner.into_reflect(),
-            Self::Enum(inner) => inner.into_reflect(),
-            Self::Array(inner) => inner.into_reflect(),
-            Self::List(inner) => inner.into_reflect(),
-            Self::Map(inner) => inner.into_reflect(),
-            Self::Scalar(inner) => inner.into_reflect(),
-            Self::Opaque(inner) => inner.into_reflect(),
-        }
-    }
-
     pub fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
         match self {
             ReflectOwned::Struct(inner) => inner.as_reflect_mut(),
@@ -890,27 +870,6 @@ pub enum ScalarOwned {
 }
 
 impl ScalarOwned {
-    pub fn into_reflect(self) -> Box<dyn Reflect> {
-        match self {
-            ScalarOwned::usize(inner) => Box::new(inner),
-            ScalarOwned::u8(inner) => Box::new(inner),
-            ScalarOwned::u16(inner) => Box::new(inner),
-            ScalarOwned::u32(inner) => Box::new(inner),
-            ScalarOwned::u64(inner) => Box::new(inner),
-            ScalarOwned::u128(inner) => Box::new(inner),
-            ScalarOwned::i8(inner) => Box::new(inner),
-            ScalarOwned::i16(inner) => Box::new(inner),
-            ScalarOwned::i32(inner) => Box::new(inner),
-            ScalarOwned::i64(inner) => Box::new(inner),
-            ScalarOwned::i128(inner) => Box::new(inner),
-            ScalarOwned::bool(inner) => Box::new(inner),
-            ScalarOwned::char(inner) => Box::new(inner),
-            ScalarOwned::f32(inner) => Box::new(inner),
-            ScalarOwned::f64(inner) => Box::new(inner),
-            ScalarOwned::String(inner) => Box::new(inner),
-        }
-    }
-
     pub fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
         match self {
             ScalarOwned::usize(inner) => inner,

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -273,10 +273,6 @@ use crate::enum_::VariantKind;
 
 macro_rules! trivial_reflect_methods {
     () => {
-        fn into_any(self: Box<Self>) -> Box<dyn Any> {
-            self
-        }
-
         fn as_any(&self) -> &dyn Any {
             self
         }
@@ -418,8 +414,6 @@ pub use self::value::Value;
 /// A reflected type.
 pub trait Reflect: Any + Send + 'static {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor>;
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any>;
 
     fn as_any(&self) -> &dyn Any;
 

--- a/crates/mirror-mirror/src/std_impls/boxed.rs
+++ b/crates/mirror-mirror/src/std_impls/boxed.rs
@@ -42,10 +42,6 @@ where
         <T as Reflect>::as_any_mut(self)
     }
 
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        <T as Reflect>::into_reflect(*self)
-    }
-
     fn as_reflect(&self) -> &dyn Reflect {
         <T as Reflect>::as_reflect(self)
     }

--- a/crates/mirror-mirror/src/std_impls/boxed.rs
+++ b/crates/mirror-mirror/src/std_impls/boxed.rs
@@ -34,10 +34,6 @@ where
         <T as Typed>::type_descriptor()
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        <T as Reflect>::into_any(*self)
-    }
-
     fn as_any(&self) -> &dyn Any {
         <T as Reflect>::as_any(self)
     }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -186,10 +186,6 @@ impl Reflect for Value {
         <Self as Typed>::type_descriptor()
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        for_each_variant!(*self, inner => Box::new(inner))
-    }
-
     fn as_any(&self) -> &dyn Any {
         for_each_variant!(self, inner => inner)
     }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -194,10 +194,6 @@ impl Reflect for Value {
         for_each_variant!(self, inner => inner)
     }
 
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        for_each_variant!(*self, inner => Box::new(inner))
-    }
-
     fn as_reflect(&self) -> &dyn Reflect {
         for_each_variant!(self, inner => inner)
     }


### PR DESCRIPTION
Consider these PR's commits as questions :grin: These methods seem unused both in the crate itself, and in our main use case. Why are they here? Do you have use cases for them in a near future? If not, I'd suggest adding them back only when needs be, following the YAGNI principle.