### PR TITLE
Implement `type_descriptor` as a default trait method

### DIFF
--- a/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
@@ -267,8 +267,6 @@ fn expand_reflect(
         quote! {
             fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 impl #impl_generics Typed for #ident #type_generics #where_clause {
-                    fn_type_descriptor!();
-
                     fn build(graph: &mut TypeGraph) -> NodeId {
                         let variants = &[#(#code_for_variants),*];
                         graph.get_or_build_node_with::<Self, _>(|graph| {

--- a/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
@@ -113,8 +113,6 @@ fn expand_reflect(
         quote! {
             fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 impl #impl_generics Typed for #ident #type_generics #where_clause {
-                    fn_type_descriptor!();
-
                     fn build(graph: &mut TypeGraph) -> NodeId {
                         graph.get_or_build_node_with::<Self, _>(|graph| {
                             let fields = &[#(#code_for_fields),*];

--- a/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
@@ -115,8 +115,6 @@ fn expand_reflect(
         quote! {
             fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                 impl #impl_generics Typed for #ident #type_generics #where_clause {
-                    fn_type_descriptor!();
-
                     fn build(graph: &mut TypeGraph) -> NodeId {
                         let fields = &[#(#code_for_fields),*];
                         graph.get_or_build_node_with::<Self, _>(|graph| {

--- a/crates/mirror-mirror/src/enum_.rs
+++ b/crates/mirror-mirror/src/enum_.rs
@@ -186,8 +186,6 @@ impl TupleVariantBuilder {
 impl Reflect for EnumValue {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for EnumValue {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -291,52 +291,6 @@ macro_rules! trivial_reflect_methods {
     };
 }
 
-#[cfg(feature = "std")]
-#[macro_export]
-macro_rules! fn_type_descriptor {
-    () => {
-        fn type_descriptor() -> $crate::__private::Cow<'static, $crate::type_info::TypeDescriptor> {
-            use std::collections::HashMap;
-            use std::sync::RwLock;
-            use $crate::__private::*;
-
-            // a map required for generic types to have different type descriptors such as
-            // `Vec<i32>` and `Vec<bool>`
-            static INFO: OnceBox<RwLock<HashMap<TypeId, &'static TypeDescriptor>>> = OnceBox::new();
-
-            let type_id = TypeId::of::<Self>();
-
-            let lock = INFO.get_or_init(Box::default);
-            if let Some(info) = lock.read().unwrap().get(&type_id) {
-                return Cow::Borrowed(info);
-            }
-
-            let mut map = lock.write().unwrap();
-            let info = map.entry(type_id).or_insert_with(|| {
-                let mut graph = TypeGraph::default();
-                let id = Self::build(&mut graph);
-                let info = TypeDescriptor::__private_new(id, graph);
-                Box::leak(Box::new(info))
-            });
-            Cow::Borrowed(*info)
-        }
-    };
-}
-
-#[cfg(not(feature = "std"))]
-#[macro_export]
-macro_rules! fn_type_descriptor {
-    () => {
-        fn type_descriptor() -> $crate::__private::Cow<'static, $crate::type_info::TypeDescriptor> {
-            use $crate::__private::*;
-
-            let mut graph = TypeGraph::default();
-            let id = Self::build(&mut graph);
-            Cow::Owned(TypeDescriptor::__private_new(id, graph))
-        }
-    };
-}
-
 /// Reflected array types.
 pub mod array;
 

--- a/crates/mirror-mirror/src/std_impls/array.rs
+++ b/crates/mirror-mirror/src/std_impls/array.rs
@@ -27,8 +27,6 @@ where
         where
             T: Typed,
         {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| ArrayNode::new::<Self, T, N>(graph))
             }

--- a/crates/mirror-mirror/src/std_impls/boxed.rs
+++ b/crates/mirror-mirror/src/std_impls/boxed.rs
@@ -24,8 +24,6 @@ where
         where
             T: Typed,
         {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 T::build(graph)
             }

--- a/crates/mirror-mirror/src/std_impls/btree_map.rs
+++ b/crates/mirror-mirror/src/std_impls/btree_map.rs
@@ -82,8 +82,6 @@ where
             K: Typed,
             V: Typed,
         {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| MapNode::new::<Self, K, V>(graph))
             }

--- a/crates/mirror-mirror/src/std_impls/vec.rs
+++ b/crates/mirror-mirror/src/std_impls/vec.rs
@@ -87,8 +87,6 @@ where
         where
             T: Typed,
         {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| ListNode::new::<Self, T>(graph))
             }

--- a/crates/mirror-mirror/src/std_impls/via_scalar.rs
+++ b/crates/mirror-mirror/src/std_impls/via_scalar.rs
@@ -19,8 +19,6 @@ macro_rules! impl_reflect_via_scalar {
             impl Reflect for $ty {
                 fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
                     impl Typed for $ty {
-                        fn_type_descriptor!();
-
                         fn build(graph: &mut TypeGraph) -> NodeId {
                             graph.get_or_build_node_with::<Self, _>(|graph| {
                                 OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/struct_.rs
+++ b/crates/mirror-mirror/src/struct_.rs
@@ -76,8 +76,6 @@ impl StructValue {
 impl Reflect for StructValue {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for StructValue {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/tuple.rs
+++ b/crates/mirror-mirror/src/tuple.rs
@@ -88,8 +88,6 @@ impl Tuple for TupleValue {
 impl Reflect for TupleValue {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for TupleValue {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)
@@ -159,8 +157,6 @@ macro_rules! impl_tuple {
         where
             $($ident: Reflect + Typed + Clone,)*
         {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     let fields = &[

--- a/crates/mirror-mirror/src/tuple_struct.rs
+++ b/crates/mirror-mirror/src/tuple_struct.rs
@@ -66,8 +66,6 @@ impl TupleStructValue {
 impl Reflect for TupleStructValue {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for TupleStructValue {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -486,8 +486,6 @@ macro_rules! scalar_typed {
     ($($ty:ident)*) => {
         $(
             impl Typed for $ty {
-                fn_type_descriptor!();
-
                 fn build(graph: &mut TypeGraph) -> NodeId {
                     graph.get_or_build_node_with::<Self, _>(|_graph| ScalarNode::$ty)
                 }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -174,8 +174,6 @@ macro_rules! for_each_variant {
 impl Reflect for Value {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
         impl Typed for Value {
-            fn_type_descriptor!();
-
             fn build(graph: &mut TypeGraph) -> NodeId {
                 graph.get_or_build_node_with::<Self, _>(|graph| {
                     OpaqueNode::new::<Self>(Default::default(), graph)


### PR DESCRIPTION
This still allows for custom implementations of that trait method, and allows making the `private_new` function private, thus allowing to drop the prefix. Also slightly cleaner. Added comments as well explaining what those do.

(FYI: the body of the method is unchanged, this is just code motion.)