### PR TITLE
Fix lossly cast in `value_to_usize`

### DIFF
--- a/crates/mirror-mirror/src/key_path.rs
+++ b/crates/mirror-mirror/src/key_path.rs
@@ -560,16 +560,30 @@ impl fmt::Display for KeyPath {
 pub(crate) fn value_to_usize(value: &Value) -> Option<usize> {
     match value {
         Value::usize(n) => Some(*n),
-        Value::u8(n) => Some(*n as usize),
-        Value::u16(n) => Some(*n as usize),
-        Value::u32(n) => Some(*n as usize),
-        Value::u64(n) => Some(*n as usize),
-        Value::u128(n) => Some(*n as usize),
-        Value::i8(n) => Some(*n as usize),
-        Value::i16(n) => Some(*n as usize),
-        Value::i32(n) => Some(*n as usize),
-        Value::i64(n) => Some(*n as usize),
-        Value::i128(n) => Some(*n as usize),
+        Value::u8(n) => Some(usize::from(*n)),
+        Value::u16(n) => Some(usize::from(*n)),
+        Value::u32(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
+        Value::u64(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
+        Value::u128(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
+        Value::i8(n) => Some(usize::try_from(*n).expect("failed to convert number to array index")),
+        Value::i16(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
+        Value::i32(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
+        Value::i64(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
+        Value::i128(n) => {
+            Some(usize::try_from(*n).expect("failed to convert number to array index"))
+        }
         Value::bool(_)
         | Value::char(_)
         | Value::f32(_)


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Turns out going `key_path::get(1)` infers `1` to be an `i32`, since `get` takes an `impl Into<Value>`. So we somehow need to cast from at least `i32` to `usize` for accessing lists and arrays with key paths.

To remove the lossly conversion I can think of two options:

1. Use `TryFrom` and panic if the conversion fails. This would only happen when accessing a very large list.
2. `key_path::get` is also used for accessing maps (hence why it takes `impl Into<Value>`) but we could make separate functions for list/array and map access. Perhaps `get_seq(usize)` and `get_map(impl Into<Value>)`.

I personally prefer option one because I like how list/array and map access is the same, but it is perhaps a bit disingenuous. I like how it matches rusts' `Index` trait though. What do you think @bnjbvr?

### Related Issues

Fixes https://github.com/EmbarkStudios/mirror-mirror/issues/76