### PR TITLE
Move glam and macaw to their own files

### DIFF
--- a/crates/mirror-mirror/src/foreign_impls/glam.rs
+++ b/crates/mirror-mirror/src/foreign_impls/glam.rs
@@ -1,0 +1,34 @@
+use glam::{Mat3, Vec2, Vec3};
+use mirror_mirror_macros::__private_derive_reflect_foreign;
+
+__private_derive_reflect_foreign! {
+    #[reflect(crate_name(crate))]
+    pub struct Vec2 {
+        pub x: f32,
+        pub y: f32,
+    }
+}
+
+__private_derive_reflect_foreign! {
+    #[reflect(crate_name(crate))]
+    pub struct Vec3 {
+        pub x: f32,
+        pub y: f32,
+        pub z: f32,
+    }
+}
+
+// `Vec4`, `Quat`, and `Mat2` are left out because glam uses bad hacks which changes the struct
+// definitions for different architectures (simd vs no simd) and cargo features. So we'd have
+// to use the same hacks in mirror-mirror which I'd like to avoid.
+
+// `Mat4` is left out because it contains `Vec4` which we don't support.
+
+__private_derive_reflect_foreign! {
+    #[reflect(crate_name(crate))]
+    pub struct Mat3 {
+        pub x_axis: Vec3,
+        pub y_axis: Vec3,
+        pub z_axis: Vec3,
+    }
+}

--- a/crates/mirror-mirror/src/foreign_impls/macaw.rs
+++ b/crates/mirror-mirror/src/foreign_impls/macaw.rs
@@ -1,0 +1,7 @@
+use macaw::ColorRgba8;
+use mirror_mirror_macros::__private_derive_reflect_foreign;
+
+__private_derive_reflect_foreign! {
+    #[reflect(crate_name(crate))]
+    pub struct ColorRgba8(pub [u8; 4]);
+}

--- a/crates/mirror-mirror/src/foreign_impls/mod.rs
+++ b/crates/mirror-mirror/src/foreign_impls/mod.rs
@@ -12,6 +12,11 @@ mod btree_map;
 mod vec;
 mod via_scalar;
 
+#[cfg(feature = "glam")]
+mod glam;
+#[cfg(feature = "macaw")]
+mod macaw;
+
 __private_derive_reflect_foreign! {
     #[reflect(opt_out(Clone, Debug), crate_name(crate))]
     enum Option<T>
@@ -78,54 +83,5 @@ __private_derive_reflect_foreign! {
         Idx: FromReflect + DescribeType,
     {
         end: Idx,
-    }
-}
-
-#[cfg(feature = "glam")]
-mod glam_impls {
-    use glam::{Mat3, Vec2, Vec3};
-    use mirror_mirror_macros::__private_derive_reflect_foreign;
-
-    __private_derive_reflect_foreign! {
-        #[reflect(crate_name(crate))]
-        pub struct Vec2 {
-            pub x: f32,
-            pub y: f32,
-        }
-    }
-
-    __private_derive_reflect_foreign! {
-        #[reflect(crate_name(crate))]
-        pub struct Vec3 {
-            pub x: f32,
-            pub y: f32,
-            pub z: f32,
-        }
-    }
-
-    // `Vec4`, `Quat`, and `Mat2` are left out because glam uses bad hacks which changes the struct
-    // definitions for different architectures (simd vs no simd) and cargo features. So we'd have
-    // to use the same hacks in mirror-mirror which I'd like to avoid.
-
-    // `Mat4` is left out because it contains `Vec4` which we don't support.
-
-    __private_derive_reflect_foreign! {
-        #[reflect(crate_name(crate))]
-        pub struct Mat3 {
-            pub x_axis: Vec3,
-            pub y_axis: Vec3,
-            pub z_axis: Vec3,
-        }
-    }
-}
-
-#[cfg(feature = "macaw")]
-mod macaw_impls {
-    use macaw::ColorRgba8;
-    use mirror_mirror_macros::__private_derive_reflect_foreign;
-
-    __private_derive_reflect_foreign! {
-        #[reflect(crate_name(crate))]
-        pub struct ColorRgba8(pub [u8; 4]);
     }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This moves the glam/macaw mods from the foreign_impl/mod.rs files to their own files in that same directory. Just feels slightly cleaner.

### Related Issues

n/a