### PR TITLE
Use implicit format-args captures where applicable

### DIFF
--- a/crates/mirror-mirror/src/enum_.rs
+++ b/crates/mirror-mirror/src/enum_.rs
@@ -230,9 +230,9 @@ impl Reflect for EnumValue {
 
     fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", self)
+            write!(f, "{self:#?}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -640,9 +640,9 @@ impl Reflect for String {
 
     fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", self)
+            write!(f, "{self:#?}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 }
@@ -1197,9 +1197,9 @@ pub fn reflect_debug(value: &dyn Reflect, f: &mut core::fmt::Formatter<'_>) -> c
         f: &mut core::fmt::Formatter<'_>,
     ) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", scalar)
+            write!(f, "{scalar:#?}")
         } else {
-            write!(f, "{:?}", scalar)
+            write!(f, "{scalar:?}")
         }
     }
 

--- a/crates/mirror-mirror/src/struct_.rs
+++ b/crates/mirror-mirror/src/struct_.rs
@@ -107,9 +107,9 @@ impl Reflect for StructValue {
 
     fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", self)
+            write!(f, "{self:#?}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 

--- a/crates/mirror-mirror/src/tests/list.rs
+++ b/crates/mirror-mirror/src/tests/list.rs
@@ -28,8 +28,8 @@ fn indexing() {
 #[test]
 fn debug() {
     let list = Vec::from([1, 2, 3]);
-    assert_eq!(format!("{:?}", list.as_reflect()), format!("{:?}", list));
-    assert_eq!(format!("{:#?}", list.as_reflect()), format!("{:#?}", list));
+    assert_eq!(format!("{:?}", list.as_reflect()), format!("{list:?}"));
+    assert_eq!(format!("{:#?}", list.as_reflect()), format!("{list:#?}"));
 }
 
 #[test]

--- a/crates/mirror-mirror/src/tuple.rs
+++ b/crates/mirror-mirror/src/tuple.rs
@@ -119,9 +119,9 @@ impl Reflect for TupleValue {
 
     fn debug(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", self)
+            write!(f, "{self:#?}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 

--- a/crates/mirror-mirror/src/tuple_struct.rs
+++ b/crates/mirror-mirror/src/tuple_struct.rs
@@ -97,9 +97,9 @@ impl Reflect for TupleStructValue {
 
     fn debug(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", self)
+            write!(f, "{self:#?}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -295,9 +295,9 @@ impl Reflect for Value {
 
     fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{:#?}", self)
+            write!(f, "{self:#?}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Moves to `format!("{x}")` instead of `format!("{}", x)`.