### PR TITLE
Make `SimpleTypeName` support types defined inside unnamed constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Make `SimpleTypeName` support types defined inside unnamed constants ([#91])
+
+[#91]: https://github.com/EmbarkStudios/mirror-mirror/pull/91
 
 # 0.1.2 (03. February, 2023)
 

--- a/crates/mirror-mirror/src/tests/simple_type_name.rs
+++ b/crates/mirror-mirror/src/tests/simple_type_name.rs
@@ -38,3 +38,22 @@ fn works() {
     // type names don't include lifetimes
     assert_eq!(simple_type_name::<Foo<'static, 10>>(), "Foo<10>");
 }
+
+#[test]
+fn type_inside_unnamed_const() {
+    trait A {
+        type T;
+    }
+
+    struct Foo;
+
+    const _: () = {
+        struct Bar<T>(T);
+
+        impl A for Foo {
+            type T = Bar<String>;
+        }
+    };
+
+    assert_eq!(simple_type_name::<<Foo as A>::T>(), "Bar<String>");
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I just discovered that if you have a type defined inside an unnamed constant like

```rust
trait A {
    type T;
}

struct Foo;

const _: () = {
    struct Bar<T>(T);

    impl A for Foo {
        type T = Bar<String>;
    }
};
```

then `type_name::<<Foo as A>::T>()` will be `crate::_::Bar`. Such code is common with macros because you can import stuff without polluting the surrounding namespace.

However `syn` does not support parsing such type names 😕 Stripping the `::_` part is probably the easiest solution.