### PR TITLE
Add methods for getting number of fields/variants in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `fields_len` methods to the following types ([#94])
+    - `StructType`
+    - `TupleStructType`
+    - `TupleType`
+    - `Variant`
+    - `StructVariant`
+    - `TupleStructVariant`
+- **added:** Add `EnumType::variants_len` ([#94])
+
+[#94]: https://github.com/EmbarkStudios/mirror-mirror/pull/94
 
 # 0.1.4 (08. February, 2023)
 

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -641,6 +641,10 @@ impl<'a> StructType<'a> {
         })
     }
 
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
+    }
+
     pub fn field_type(self, name: &str) -> Option<NamedField<'a>> {
         let node = self.node.fields.get(name)?;
         Some(NamedField {
@@ -692,6 +696,10 @@ impl<'a> TupleStructType<'a> {
         })
     }
 
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
+    }
+
     pub fn field_type_at(self, index: usize) -> Option<UnnamedField<'a>> {
         let node = self.node.fields.get(index)?;
         Some(UnnamedField {
@@ -736,6 +744,10 @@ impl<'a> TupleType<'a> {
             node,
             graph: self.graph,
         })
+    }
+
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
     }
 
     pub fn field_type_at(self, index: usize) -> Option<UnnamedField<'a>> {
@@ -797,6 +809,10 @@ impl<'a> EnumType<'a> {
         })
     }
 
+    pub fn variants_len(self) -> usize {
+        self.node.variants.len()
+    }
+
     pub fn variant(self, name: &str) -> Option<Variant<'a>> {
         self.variants().find(|variant| variant.name() == name)
     }
@@ -849,6 +865,14 @@ impl<'a> Variant<'a> {
                 as Box<dyn Iterator<Item = VariantField<'a>>>,
             Variant::Tuple(inner) => Box::new(inner.field_types().map(VariantField::Unnamed)),
             Variant::Unit(_) => Box::new(core::iter::empty()),
+        }
+    }
+
+    pub fn fields_len(self) -> usize {
+        match self {
+            Variant::Struct(inner) => inner.fields_len(),
+            Variant::Tuple(inner) => inner.fields_len(),
+            Variant::Unit(_) => 0,
         }
     }
 
@@ -967,6 +991,10 @@ impl<'a> StructVariant<'a> {
         })
     }
 
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
+    }
+
     pub fn field_type(self, name: &str) -> Option<NamedField<'a>> {
         let node = self.node.fields.get(name)?;
         Some(NamedField {
@@ -1017,6 +1045,10 @@ impl<'a> TupleVariant<'a> {
             node,
             graph: self.graph,
         })
+    }
+
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
     }
 
     pub fn field_type_at(self, index: usize) -> Option<UnnamedField<'a>> {


### PR DESCRIPTION
I'm working on being able to pretty print types. That requires checking the number of fields/variants in a type to print the right newlines.

Currently we just expose an iterator over the fields so knowing upfront whether its empty is a little tricky.