### PR TITLE
Support pretty printing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.1.3 (08. February, 2023)
+
 - **fixed:** Make `SimpleTypeName` support types defined inside unnamed constants ([#91])
 
 [#91]: https://github.com/EmbarkStudios/mirror-mirror/pull/91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `StructVariant`
     - `TupleStructVariant`
 - **added:** Add `EnumType::variants_len` ([#94])
+- **added:** Support pretty printing types ([#95])
 
 [#94]: https://github.com/EmbarkStudios/mirror-mirror/pull/94
+[#95]: https://github.com/EmbarkStudios/mirror-mirror/pull/95
 
 # 0.1.4 (08. February, 2023)
 

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-mirror"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Embark <opensource@embark-studios.com>", "David Pedersen <david.pdrsn@gmail.com>"]
 repository = "https://github.com/EmbarkStudios/mirror-mirror"

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -22,10 +22,12 @@ use crate::Reflect;
 use crate::Value;
 
 pub mod graph;
+pub mod pretty_print;
 
 #[cfg(feature = "std")]
 mod simple_type_name;
 
+pub use self::pretty_print::{PrettyPrintRoot, RootPrettyPrinter};
 #[cfg(feature = "std")]
 pub use self::simple_type_name::SimpleTypeName;
 
@@ -639,6 +641,10 @@ impl<'a> StructType<'a> {
             node,
             graph: self.graph,
         })
+    }
+
+    pub fn fields_len(&self) -> usize {
+        self.node.fields.len()
     }
 
     pub fn field_type(self, name: &str) -> Option<NamedField<'a>> {

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -698,6 +698,10 @@ impl<'a> TupleStructType<'a> {
         })
     }
 
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
+    }
+
     pub fn field_type_at(self, index: usize) -> Option<UnnamedField<'a>> {
         let node = self.node.fields.get(index)?;
         Some(UnnamedField {
@@ -742,6 +746,10 @@ impl<'a> TupleType<'a> {
             node,
             graph: self.graph,
         })
+    }
+
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
     }
 
     pub fn field_type_at(self, index: usize) -> Option<UnnamedField<'a>> {
@@ -801,6 +809,10 @@ impl<'a> EnumType<'a> {
                 graph: self.graph,
             }),
         })
+    }
+
+    pub fn variants_len(self) -> usize {
+        self.node.variants.len()
     }
 
     pub fn variant(self, name: &str) -> Option<Variant<'a>> {
@@ -971,6 +983,10 @@ impl<'a> StructVariant<'a> {
             node,
             graph: self.graph,
         })
+    }
+
+    pub fn fields_len(self) -> usize {
+        self.node.fields.len()
     }
 
     pub fn field_type(self, name: &str) -> Option<NamedField<'a>> {

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -459,7 +459,13 @@ mod private {
 
     pub trait Sealed {}
 
+    impl Sealed for TypeDescriptor {}
     impl<'a> Sealed for &'a TypeDescriptor {}
+    impl<'a> Sealed for TupleType<'a> {}
+    impl<'a> Sealed for ListType<'a> {}
+    impl<'a> Sealed for ArrayType<'a> {}
+    impl<'a> Sealed for MapType<'a> {}
+    impl Sealed for ScalarType {}
     impl Sealed for Type<'_> {}
     impl Sealed for StructType<'_> {}
     impl Sealed for TupleStructType<'_> {}

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -63,7 +63,7 @@ fn simple_type_name_fmt(type_name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Res
     f.write_str(type_name)
 }
 
-const IDENT: &str = "    ";
+const TAB: &str = "    ";
 
 impl<'a> PrettyPrintRoot for StructType<'a> {
     fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -1,11 +1,8 @@
-#![allow(missing_debug_implementations, clippy::todo)]
-
 use core::fmt::{self, Write};
 
 use super::*;
 
-// TODO(david): seal this
-pub trait PrettyPrintRoot {
+pub trait PrettyPrintRoot: super::private::Sealed {
     fn pretty_print_root(&self) -> RootPrettyPrinter<'_, Self> {
         RootPrettyPrinter { ty: self }
     }
@@ -13,6 +10,7 @@ pub trait PrettyPrintRoot {
     fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 }
 
+#[derive(Debug)]
 pub struct RootPrettyPrinter<'a, T>
 where
     T: ?Sized,
@@ -42,11 +40,11 @@ impl<'a> PrettyPrintRoot for Type<'a> {
             Type::TupleStruct(inner) => inner.pretty_root_fmt(f),
             Type::Tuple(inner) => inner.pretty_root_fmt(f),
             Type::Enum(inner) => inner.pretty_root_fmt(f),
-            Type::List(_) => todo!(),
-            Type::Array(_) => todo!(),
-            Type::Map(_) => todo!(),
-            Type::Scalar(_) => todo!(),
-            Type::Opaque(_) => todo!(),
+            Type::List(inner) => inner.pretty_root_fmt(f),
+            Type::Array(inner) => inner.pretty_root_fmt(f),
+            Type::Map(inner) => inner.pretty_root_fmt(f),
+            Type::Scalar(inner) => inner.pretty_root_fmt(f),
+            Type::Opaque(inner) => inner.pretty_root_fmt(f),
         }
     }
 }
@@ -126,29 +124,114 @@ impl<'a> PrettyPrintRoot for EnumType<'a> {
                     Variant::Struct(struct_variant) => {
                         f.write_str(IDENT)?;
                         f.write_str(struct_variant.name())?;
-                    },
-                    Variant::Tuple(_) => {},
-                    Variant::Unit(_) => {},
+                        f.write_str(" {")?;
+                        if struct_variant.fields_len() != 0 {
+                            f.write_char('\n')?;
+                            for field in struct_variant.field_types() {
+                                f.write_str(IDENT)?;
+                                f.write_str(IDENT)?;
+                                f.write_str(field.name())?;
+                                f.write_str(": ")?;
+                                simple_type_name_fmt(field.get_type().type_name(), f)?;
+                                f.write_str(",")?;
+                                f.write_char('\n')?;
+                            }
+                            f.write_str(IDENT)?;
+                        }
+                        f.write_str("},\n")?;
+                    }
+                    Variant::Tuple(tuple_variant) => {
+                        f.write_str(IDENT)?;
+                        f.write_str(tuple_variant.name())?;
+                        f.write_str("(")?;
+                        let mut fields = tuple_variant.field_types().peekable();
+                        while let Some(field) = fields.next() {
+                            simple_type_name_fmt(field.get_type().type_name(), f)?;
+                            if fields.peek().is_some() {
+                                f.write_str(", ")?;
+                            }
+                        }
+                        f.write_str("),\n")?;
+                    }
+                    Variant::Unit(unit_variant) => {
+                        f.write_str(IDENT)?;
+                        f.write_str(unit_variant.name())?;
+                        f.write_str(",\n")?;
+                    }
                 }
             }
-
-        //     for field in self.field_types() {
-        //         f.write_str(IDENT)?;
-        //         f.write_str(field.name())?;
-        //         f.write_str(": ")?;
-        //         simple_type_name_fmt(field.get_type().type_name(), f)?;
-        //         f.write_str(",")?;
-        //         f.write_char('\n')?;
-        //     }
         }
         f.write_str("}")?;
         Ok(())
     }
 }
 
+impl<'a> PrettyPrintRoot for ListType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_char('[')?;
+        simple_type_name_fmt(self.element_type().type_name(), f)?;
+        f.write_char(']')?;
+        Ok(())
+    }
+}
+
+impl<'a> PrettyPrintRoot for ArrayType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_char('[')?;
+        simple_type_name_fmt(self.element_type().type_name(), f)?;
+        f.write_str("; ")?;
+        write!(f, "{}", self.len())?;
+        f.write_char(']')?;
+        Ok(())
+    }
+}
+
+impl<'a> PrettyPrintRoot for MapType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_char('[')?;
+        simple_type_name_fmt(self.key_type().type_name(), f)?;
+        f.write_str(": ")?;
+        simple_type_name_fmt(self.value_type().type_name(), f)?;
+        f.write_char(']')?;
+        Ok(())
+    }
+}
+
+impl PrettyPrintRoot for ScalarType {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScalarType::usize => f.write_str("usize")?,
+            ScalarType::u8 => f.write_str("u8")?,
+            ScalarType::u16 => f.write_str("u16")?,
+            ScalarType::u32 => f.write_str("u32")?,
+            ScalarType::u64 => f.write_str("u64")?,
+            ScalarType::u128 => f.write_str("u128")?,
+            ScalarType::i8 => f.write_str("i8")?,
+            ScalarType::i16 => f.write_str("i16")?,
+            ScalarType::i32 => f.write_str("i32")?,
+            ScalarType::i64 => f.write_str("i64")?,
+            ScalarType::i128 => f.write_str("i128")?,
+            ScalarType::bool => f.write_str("bool")?,
+            ScalarType::char => f.write_str("char")?,
+            ScalarType::f32 => f.write_str("f32")?,
+            ScalarType::f64 => f.write_str("f64")?,
+            ScalarType::String => f.write_str("String")?,
+        }
+        Ok(())
+    }
+}
+
+impl<'a> PrettyPrintRoot for OpaqueType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        simple_type_name_fmt(self.type_name(), f)?;
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
+
     use super::*;
     use crate::{DescribeType, Reflect};
 
@@ -211,7 +294,7 @@ mod tests {
         #[derive(Reflect, Clone, Debug)]
         #[reflect(crate_name(crate))]
         enum Foo {
-            A(String),
+            A(String, i32),
             A2(),
             B { b: Vec<i32> },
             B2 {},
@@ -224,14 +307,54 @@ mod tests {
         assert_eq!(
             println_and_format!("{pp}"),
             r#"enum Foo {
-    A(String),
-    A2,
+    A(String, i32),
+    A2(),
     B {
         b: Vec<i32>,
     },
-    B2,
+    B2 {},
     C,
 }"#
         );
+    }
+
+    #[test]
+    fn list() {
+        let type_descriptor = <Vec<(String, i32)> as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"[(String, i32)]"#);
+    }
+
+    #[test]
+    fn array() {
+        let type_descriptor = <[(String, i32); 10] as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"[(String, i32); 10]"#);
+    }
+
+    #[test]
+    fn map() {
+        let type_descriptor = <BTreeMap<String, i32> as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"[String: i32]"#);
+    }
+
+    #[test]
+    fn scalar() {
+        let type_descriptor = <String as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"String"#);
+    }
+
+    #[test]
+    fn opaque() {
+        let type_descriptor = <Duration as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"Duration"#);
     }
 }

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -1,0 +1,171 @@
+#![allow(missing_debug_implementations, clippy::todo)]
+
+use core::fmt::{self, Write};
+
+use super::*;
+
+pub trait PrettyPrintRoot {
+    fn pretty_print_root(&self) -> RootPrettyPrinter<'_, Self> {
+        RootPrettyPrinter { ty: self }
+    }
+
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
+}
+
+pub struct RootPrettyPrinter<'a, T>
+where
+    T: ?Sized,
+{
+    ty: &'a T,
+}
+
+impl<'a, T> fmt::Display for RootPrettyPrinter<'a, T>
+where
+    T: PrettyPrintRoot,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.ty.pretty_root_fmt(f)
+    }
+}
+
+impl PrettyPrintRoot for TypeDescriptor {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get_type().pretty_root_fmt(f)
+    }
+}
+
+impl<'a> PrettyPrintRoot for Type<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Type::Struct(inner) => inner.pretty_root_fmt(f),
+            Type::TupleStruct(inner) => inner.pretty_root_fmt(f),
+            Type::Tuple(inner) => inner.pretty_root_fmt(f),
+            Type::Enum(_) => todo!(),
+            Type::List(_) => todo!(),
+            Type::Array(_) => todo!(),
+            Type::Map(_) => todo!(),
+            Type::Scalar(_) => todo!(),
+            Type::Opaque(_) => todo!(),
+        }
+    }
+}
+
+fn simple_type_name_fmt(type_name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if let Some(name) = SimpleTypeName::new(type_name) {
+        write!(f, "{name}")
+    } else {
+        f.write_str(type_name)
+    }
+}
+
+const IDENT: &str = "    ";
+
+impl<'a> PrettyPrintRoot for StructType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("struct ")?;
+        simple_type_name_fmt(self.type_name(), f)?;
+        f.write_str(" {")?;
+        if self.fields_len() != 0 {
+            f.write_char('\n')?;
+            for field in self.field_types() {
+                f.write_str(IDENT)?;
+                f.write_str(field.name())?;
+                f.write_str(": ")?;
+                simple_type_name_fmt(field.get_type().type_name(), f)?;
+                f.write_str(",")?;
+                f.write_char('\n')?;
+            }
+        }
+        f.write_str("}")?;
+        Ok(())
+    }
+}
+
+impl<'a> PrettyPrintRoot for TupleStructType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("struct ")?;
+        simple_type_name_fmt(self.type_name(), f)?;
+        f.write_str("(")?;
+        let mut fields = self.field_types().peekable();
+        while let Some(field) = fields.next() {
+            simple_type_name_fmt(field.get_type().type_name(), f)?;
+            if fields.peek().is_some() {
+                f.write_str(", ")?;
+            }
+        }
+        f.write_str(")")?;
+        Ok(())
+    }
+}
+
+impl<'a> PrettyPrintRoot for TupleType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("(")?;
+        let mut fields = self.field_types().peekable();
+        while let Some(field) = fields.next() {
+            simple_type_name_fmt(field.get_type().type_name(), f)?;
+            if fields.peek().is_some() {
+                f.write_str(", ")?;
+            }
+        }
+        f.write_str(")")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DescribeType, Reflect};
+
+    // makes it a little easier to see what the output was if a test fails
+    macro_rules! println_and_format {
+        ($($tt:tt)*) => {
+            {
+                println!($($tt)*);
+                format!($($tt)*)
+            }
+        };
+    }
+
+    #[test]
+    fn struct_() {
+        #[derive(Reflect, Clone, Debug)]
+        #[reflect(crate_name(crate))]
+        struct Foo {
+            a: String,
+            b: Vec<i32>,
+        }
+
+        let type_descriptor = <Foo as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(
+            println_and_format!("{pp}"),
+            r#"struct Foo {
+    a: String,
+    b: Vec<i32>,
+}"#
+        );
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Reflect, Clone, Debug)]
+        #[reflect(crate_name(crate))]
+        struct Foo(String, Vec<i32>);
+
+        let type_descriptor = <Foo as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"struct Foo(String, Vec<i32>)"#);
+    }
+
+    #[test]
+    fn tuple() {
+        let type_descriptor = <(String, Vec<i32>) as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"(String, Vec<i32>)"#);
+    }
+}

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -73,7 +73,7 @@ impl<'a> PrettyPrintRoot for StructType<'a> {
         if self.fields_len() != 0 {
             f.write_char('\n')?;
             for field in self.field_types() {
-                f.write_str(IDENT)?;
+                f.write_str(TAB)?;
                 f.write_str(field.name())?;
                 f.write_str(": ")?;
                 simple_type_name_fmt(field.get_type().type_name(), f)?;
@@ -128,26 +128,26 @@ impl<'a> PrettyPrintRoot for EnumType<'a> {
             for variant in self.variants() {
                 match variant {
                     Variant::Struct(struct_variant) => {
-                        f.write_str(IDENT)?;
+                        f.write_str(TAB)?;
                         f.write_str(struct_variant.name())?;
                         f.write_str(" {")?;
                         if struct_variant.fields_len() != 0 {
                             f.write_char('\n')?;
                             for field in struct_variant.field_types() {
-                                f.write_str(IDENT)?;
-                                f.write_str(IDENT)?;
+                                f.write_str(TAB)?;
+                                f.write_str(TAB)?;
                                 f.write_str(field.name())?;
                                 f.write_str(": ")?;
                                 simple_type_name_fmt(field.get_type().type_name(), f)?;
                                 f.write_str(",")?;
                                 f.write_char('\n')?;
                             }
-                            f.write_str(IDENT)?;
+                            f.write_str(TAB)?;
                         }
                         f.write_str("},\n")?;
                     }
                     Variant::Tuple(tuple_variant) => {
-                        f.write_str(IDENT)?;
+                        f.write_str(TAB)?;
                         f.write_str(tuple_variant.name())?;
                         f.write_str("(")?;
                         let mut fields = tuple_variant.field_types().peekable();
@@ -160,7 +160,7 @@ impl<'a> PrettyPrintRoot for EnumType<'a> {
                         f.write_str("),\n")?;
                     }
                     Variant::Unit(unit_variant) => {
-                        f.write_str(IDENT)?;
+                        f.write_str(TAB)?;
                         f.write_str(unit_variant.name())?;
                         f.write_str(",\n")?;
                     }

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -267,6 +267,18 @@ mod tests {
     }
 
     #[test]
+    fn struct_empty() {
+        #[derive(Reflect, Clone, Debug)]
+        #[reflect(crate_name(crate))]
+        struct Foo {}
+
+        let type_descriptor = <Foo as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"struct Foo {}"#);
+    }
+
+    #[test]
     fn tuple_struct() {
         #[derive(Reflect, Clone, Debug)]
         #[reflect(crate_name(crate))]
@@ -279,6 +291,31 @@ mod tests {
             println_and_format!("{pp}"),
             r#"struct Foo(String, Vec<i32>)"#
         );
+    }
+
+    #[test]
+    fn tuple_struct_empty() {
+        #[derive(Reflect, Clone, Debug)]
+        #[reflect(crate_name(crate))]
+        struct Foo();
+
+        let type_descriptor = <Foo as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        assert_eq!(println_and_format!("{pp}"), r#"struct Foo()"#);
+    }
+
+    #[test]
+    fn unit_struct() {
+        #[derive(Reflect, Clone, Debug)]
+        #[reflect(crate_name(crate))]
+        struct Foo;
+
+        let type_descriptor = <Foo as DescribeType>::type_descriptor();
+        let pp = type_descriptor.pretty_print_root();
+
+        // unit structs are treated as empty structs
+        assert_eq!(println_and_format!("{pp}"), r#"struct Foo {}"#);
     }
 
     #[test]

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -49,12 +49,18 @@ impl<'a> PrettyPrintRoot for Type<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 fn simple_type_name_fmt(type_name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if let Some(name) = SimpleTypeName::new(type_name) {
+    if let Some(name) = super::SimpleTypeName::new(type_name) {
         write!(f, "{name}")
     } else {
         f.write_str(type_name)
     }
+}
+
+#[cfg(not(feature = "std"))]
+fn simple_type_name_fmt(type_name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(type_name)
 }
 
 const IDENT: &str = "    ";


### PR DESCRIPTION
This makes it possible to pretty print type descriptors:

```rust
#[derive(Reflect, Clone, Debug)]
struct Foo {
    a: String,
    b: Vec<i32>,
}

let type_descriptor = <Foo as DescribeType>::type_descriptor();
println!("{}", type_descriptor.pretty_print_root());
```

That will print

```
struct Foo {
    a: String,
    b: Vec<i32>,
}
```

This is something I've wanted for debugging to visualize which type descriptors are being sent around. The debug representation of `TypeDescriptor` isn't very helpful since it contains the whole tree of types.