### PR TITLE
Move `DescribeType` impl outside of `fn type_descriptor` method

### DIFF
--- a/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
@@ -20,16 +20,105 @@ pub(super) fn expand(
 ) -> syn::Result<TokenStream> {
     let variants = VariantData::try_from_enum(&enum_)?;
 
+    let describe_type = expand_describe_type(ident, &variants, &attrs, generics);
     let reflect = expand_reflect(ident, &variants, &attrs, generics)?;
     let from_reflect = (!attrs.from_reflect_opt_out)
         .then(|| expand_from_reflect(ident, &variants, &attrs, generics));
     let enum_ = expand_enum(ident, &variants, &attrs, generics);
 
     Ok(quote! {
+        #describe_type
         #reflect
         #from_reflect
         #enum_
     })
+}
+
+fn expand_describe_type(
+    ident: &Ident,
+    variants: &[VariantData<'_>],
+    attrs: &ItemAttrs,
+    generics: &Generics<'_>,
+) -> TokenStream {
+    let code_for_variants = variants.iter().filter(filter_out_skipped).map(|variant| {
+        let variant_ident_string = stringify(&variant.ident);
+        let meta = variant.attrs.meta();
+        let docs = variant.attrs.docs();
+
+        match &variant.fields {
+            FieldsData::Named(fields) => {
+                let fields = fields.iter().filter(filter_out_skipped).map(|field| {
+                    let ident = &field.ident;
+                    let field_name = stringify(ident);
+                    let field_ty = &field.ty;
+                    let meta = field.attrs.meta();
+                    let docs = field.attrs.docs();
+                    quote! {
+                        NamedFieldNode::new::<#field_ty>(#field_name, #meta, #docs, graph)
+                    }
+                });
+
+                quote! {
+                    VariantNode::Struct(
+                        StructVariantNode::new(
+                            #variant_ident_string,
+                            &[#(#fields),*],
+                            #meta,
+                            #docs,
+                        )
+                    )
+                }
+            }
+            FieldsData::Unnamed(fields) => {
+                let fields = fields.iter().filter(filter_out_skipped).map(|field| {
+                    let field_ty = &field.ty;
+                    let meta = field.attrs.meta();
+                    let docs = field.attrs.docs();
+                    quote! {
+                        UnnamedFieldNode::new::<#field_ty>(#meta, #docs, graph)
+                    }
+                });
+
+                quote! {
+                    VariantNode::Tuple(
+                        TupleVariantNode::new(
+                            #variant_ident_string,
+                            &[#(#fields),*],
+                            #meta,
+                            #docs,
+                        )
+                    )
+                }
+            }
+            FieldsData::Unit => quote! {
+                VariantNode::Unit(UnitVariantNode::new(
+                    #variant_ident_string,
+                    #meta,
+                    #docs,
+                ))
+            },
+        }
+    });
+
+    let meta = attrs.meta();
+    let docs = attrs.docs();
+
+    let Generics {
+        impl_generics,
+        type_generics,
+        where_clause,
+    } = generics;
+
+    quote! {
+        impl #impl_generics DescribeType for #ident #type_generics #where_clause {
+            fn build(graph: &mut TypeGraph) -> NodeId {
+                let variants = &[#(#code_for_variants),*];
+                graph.get_or_build_node_with::<Self, _>(|graph| {
+                    EnumNode::new::<Self>(variants, #meta, #docs)
+                })
+            }
+        }
+    }
 }
 
 fn expand_reflect(
@@ -194,89 +283,9 @@ fn expand_reflect(
         }
     };
 
-    let fn_type_info = {
-        let code_for_variants = variants.iter().filter(filter_out_skipped).map(|variant| {
-            let variant_ident_string = stringify(&variant.ident);
-            let meta = variant.attrs.meta();
-            let docs = variant.attrs.docs();
-
-            match &variant.fields {
-                FieldsData::Named(fields) => {
-                    let fields = fields.iter().filter(filter_out_skipped).map(|field| {
-                        let ident = &field.ident;
-                        let field_name = stringify(ident);
-                        let field_ty = &field.ty;
-                        let meta = field.attrs.meta();
-                        let docs = field.attrs.docs();
-                        quote! {
-                            NamedFieldNode::new::<#field_ty>(#field_name, #meta, #docs, graph)
-                        }
-                    });
-
-                    quote! {
-                        VariantNode::Struct(
-                            StructVariantNode::new(
-                                #variant_ident_string,
-                                &[#(#fields),*],
-                                #meta,
-                                #docs,
-                            )
-                        )
-                    }
-                }
-                FieldsData::Unnamed(fields) => {
-                    let fields = fields.iter().filter(filter_out_skipped).map(|field| {
-                        let field_ty = &field.ty;
-                        let meta = field.attrs.meta();
-                        let docs = field.attrs.docs();
-                        quote! {
-                            UnnamedFieldNode::new::<#field_ty>(#meta, #docs, graph)
-                        }
-                    });
-
-                    quote! {
-                        VariantNode::Tuple(
-                            TupleVariantNode::new(
-                                #variant_ident_string,
-                                &[#(#fields),*],
-                                #meta,
-                                #docs,
-                            )
-                        )
-                    }
-                }
-                FieldsData::Unit => quote! {
-                    VariantNode::Unit(UnitVariantNode::new(
-                        #variant_ident_string,
-                        #meta,
-                        #docs,
-                    ))
-                },
-            }
-        });
-
-        let meta = attrs.meta();
-        let docs = attrs.docs();
-
-        let Generics {
-            impl_generics,
-            type_generics,
-            where_clause,
-        } = generics;
-
-        quote! {
-            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-                impl #impl_generics DescribeType for #ident #type_generics #where_clause {
-                    fn build(graph: &mut TypeGraph) -> NodeId {
-                        let variants = &[#(#code_for_variants),*];
-                        graph.get_or_build_node_with::<Self, _>(|graph| {
-                            EnumNode::new::<Self>(variants, #meta, #docs)
-                        })
-                    }
-                }
-
-                <Self as DescribeType>::type_descriptor()
-            }
+    let fn_type_info = quote! {
+        fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
+            <Self as DescribeType>::type_descriptor()
         }
     };
 

--- a/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
@@ -25,16 +25,59 @@ pub(super) fn expand(
 
     let fields = fields.named;
 
+    let describe_type = expand_describe_type(ident, &fields, &attrs, &field_attrs, generics);
     let reflect = expand_reflect(ident, &fields, &attrs, &field_attrs, generics);
     let from_reflect = (!attrs.from_reflect_opt_out)
         .then(|| expand_from_reflect(ident, &attrs, &fields, &field_attrs, generics));
     let struct_ = expand_struct(ident, &fields, &attrs, &field_attrs, generics);
 
     Ok(quote! {
+        #describe_type
         #reflect
         #from_reflect
         #struct_
     })
+}
+
+fn expand_describe_type(
+    ident: &Ident,
+    fields: &Fields,
+    attrs: &ItemAttrs,
+    field_attrs: &AttrsDatabase<Ident>,
+    generics: &Generics<'_>,
+) -> TokenStream {
+    let code_for_fields = fields
+        .iter()
+        .filter(field_attrs.filter_out_skipped_named())
+        .map(|field| {
+            let name = stringify(&field.ident);
+            let field_ty = &field.ty;
+            let ident = field.ident.as_ref().unwrap();
+            let meta = field_attrs.meta(ident);
+            let docs = field_attrs.docs(ident);
+            quote! {
+                NamedFieldNode::new::<#field_ty>(#name, #meta, #docs, graph)
+            }
+        });
+
+    let meta = attrs.meta();
+    let docs = attrs.docs();
+    let Generics {
+        impl_generics,
+        type_generics,
+        where_clause,
+    } = generics;
+
+    quote! {
+        impl #impl_generics DescribeType for #ident #type_generics #where_clause {
+            fn build(graph: &mut TypeGraph) -> NodeId {
+                graph.get_or_build_node_with::<Self, _>(|graph| {
+                    let fields = &[#(#code_for_fields),*];
+                    StructNode::new::<Self>(fields, #meta, #docs)
+                })
+            }
+        }
+    }
 }
 
 fn expand_reflect(
@@ -87,42 +130,9 @@ fn expand_reflect(
         }
     };
 
-    let fn_type_info = {
-        let code_for_fields = fields
-            .iter()
-            .filter(field_attrs.filter_out_skipped_named())
-            .map(|field| {
-                let name = stringify(&field.ident);
-                let field_ty = &field.ty;
-                let ident = field.ident.as_ref().unwrap();
-                let meta = field_attrs.meta(ident);
-                let docs = field_attrs.docs(ident);
-                quote! {
-                    NamedFieldNode::new::<#field_ty>(#name, #meta, #docs, graph)
-                }
-            });
-
-        let meta = attrs.meta();
-        let docs = attrs.docs();
-        let Generics {
-            impl_generics,
-            type_generics,
-            where_clause,
-        } = generics;
-
-        quote! {
-            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-                impl #impl_generics DescribeType for #ident #type_generics #where_clause {
-                    fn build(graph: &mut TypeGraph) -> NodeId {
-                        graph.get_or_build_node_with::<Self, _>(|graph| {
-                            let fields = &[#(#code_for_fields),*];
-                            StructNode::new::<Self>(fields, #meta, #docs)
-                        })
-                    }
-                }
-
-                <Self as DescribeType>::type_descriptor()
-            }
+    let fn_type_info = quote! {
+        fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
+            <Self as DescribeType>::type_descriptor()
         }
     };
 

--- a/crates/mirror-mirror/src/enum_.rs
+++ b/crates/mirror-mirror/src/enum_.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -20,7 +19,6 @@ use crate::ReflectOwned;
 use crate::ReflectRef;
 use crate::Struct;
 use crate::Tuple;
-use crate::TypeDescriptor;
 use crate::Value;
 
 /// A reflected enum type.
@@ -183,18 +181,15 @@ impl TupleVariantBuilder {
     }
 }
 
-impl Reflect for EnumValue {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl DescribeType for EnumValue {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| {
-                    OpaqueNode::new::<Self>(Default::default(), graph)
-                })
-            }
-        }
-        <Self as DescribeType>::type_descriptor()
+impl DescribeType for EnumValue {
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| {
+            OpaqueNode::new::<Self>(Default::default(), graph)
+        })
     }
+}
 
+impl Reflect for EnumValue {
     trivial_reflect_methods!();
 
     fn patch(&mut self, value: &dyn Reflect) {

--- a/crates/mirror-mirror/src/foreign_impls/array.rs
+++ b/crates/mirror-mirror/src/foreign_impls/array.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::any::Any;
@@ -15,26 +14,21 @@ use crate::Reflect;
 use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
-use crate::TypeDescriptor;
 use crate::Value;
+
+impl<T, const N: usize> DescribeType for [T; N]
+where
+    T: DescribeType,
+{
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| ArrayNode::new::<Self, T, N>(graph))
+    }
+}
 
 impl<T, const N: usize> Reflect for [T; N]
 where
     T: FromReflect + DescribeType,
 {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl<T, const N: usize> DescribeType for [T; N]
-        where
-            T: DescribeType,
-        {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| ArrayNode::new::<Self, T, N>(graph))
-            }
-        }
-
-        <Self as DescribeType>::type_descriptor()
-    }
-
     trivial_reflect_methods!();
 
     fn reflect_owned(self: Box<Self>) -> ReflectOwned {

--- a/crates/mirror-mirror/src/foreign_impls/boxed.rs
+++ b/crates/mirror-mirror/src/foreign_impls/boxed.rs
@@ -3,6 +3,7 @@ use alloc::boxed::Box;
 use core::any::Any;
 use core::fmt;
 
+use crate::TypeDescriptor;
 use crate::reflect_debug;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -12,23 +13,22 @@ use crate::Reflect;
 use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
-use crate::TypeDescriptor;
 use crate::Value;
+
+impl<T> DescribeType for Box<T>
+where
+    T: DescribeType,
+{
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        T::build(graph)
+    }
+}
 
 impl<T> Reflect for Box<T>
 where
     T: Reflect + DescribeType,
 {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl<T> DescribeType for Box<T>
-        where
-            T: DescribeType,
-        {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                T::build(graph)
-            }
-        }
-
         <T as DescribeType>::type_descriptor()
     }
 

--- a/crates/mirror-mirror/src/foreign_impls/btree_map.rs
+++ b/crates/mirror-mirror/src/foreign_impls/btree_map.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use core::any::Any;
@@ -15,7 +14,6 @@ use crate::Reflect;
 use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
-use crate::TypeDescriptor;
 use crate::Value;
 
 impl<K, V> Map for BTreeMap<K, V>
@@ -71,25 +69,21 @@ where
     }
 }
 
+impl<K, V> DescribeType for BTreeMap<K, V>
+where
+    K: DescribeType,
+    V: DescribeType,
+{
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| MapNode::new::<Self, K, V>(graph))
+    }
+}
+
 impl<K, V> Reflect for BTreeMap<K, V>
 where
     K: FromReflect + DescribeType + Ord,
     V: FromReflect + DescribeType,
 {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl<K, V> DescribeType for BTreeMap<K, V>
-        where
-            K: DescribeType,
-            V: DescribeType,
-        {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| MapNode::new::<Self, K, V>(graph))
-            }
-        }
-
-        <Self as DescribeType>::type_descriptor()
-    }
-
     trivial_reflect_methods!();
 
     fn reflect_owned(self: Box<Self>) -> ReflectOwned {

--- a/crates/mirror-mirror/src/foreign_impls/vec.rs
+++ b/crates/mirror-mirror/src/foreign_impls/vec.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::any::Any;
@@ -15,7 +14,6 @@ use crate::Reflect;
 use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
-use crate::TypeDescriptor;
 use crate::Value;
 
 impl<T> List for Vec<T>
@@ -78,23 +76,19 @@ where
     }
 }
 
+impl<T> DescribeType for Vec<T>
+where
+    T: DescribeType,
+{
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| ListNode::new::<Self, T>(graph))
+    }
+}
+
 impl<T> Reflect for Vec<T>
 where
     T: FromReflect + DescribeType,
 {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl<T> DescribeType for Vec<T>
-        where
-            T: DescribeType,
-        {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| ListNode::new::<Self, T>(graph))
-            }
-        }
-
-        <Self as DescribeType>::type_descriptor()
-    }
-
     trivial_reflect_methods!();
 
     fn patch(&mut self, value: &dyn Reflect) {

--- a/crates/mirror-mirror/src/foreign_impls/via_scalar.rs
+++ b/crates/mirror-mirror/src/foreign_impls/via_scalar.rs
@@ -16,18 +16,15 @@ macro_rules! impl_reflect_via_scalar {
         const _: () = {
             use $crate::__private::*;
 
-            impl Reflect for $ty {
-                fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-                    impl DescribeType for $ty {
-                        fn build(graph: &mut TypeGraph) -> NodeId {
-                            graph.get_or_build_node_with::<Self, _>(|graph| {
-                                OpaqueNode::new::<Self>(Default::default(), graph)
-                            })
-                        }
-                    }
-                    <Self as DescribeType>::type_descriptor()
+            impl DescribeType for $ty {
+                fn build(graph: &mut TypeGraph) -> NodeId {
+                    graph.get_or_build_node_with::<Self, _>(|graph| {
+                        OpaqueNode::new::<Self>(Default::default(), graph)
+                    })
                 }
+            }
 
+            impl Reflect for $ty {
                 trivial_reflect_methods!();
 
                 fn reflect_owned(self: Box<Self>) -> ReflectOwned {

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -277,6 +277,10 @@ use crate::enum_::VariantKind;
 
 macro_rules! trivial_reflect_methods {
     () => {
+        fn type_descriptor(&self) -> alloc::borrow::Cow<'static, $crate::type_info::TypeDescriptor> {
+            <Self as $crate::type_info::DescribeType>::type_descriptor()
+        }
+
         fn as_any(&self) -> &dyn Any {
             self
         }
@@ -532,10 +536,6 @@ macro_rules! impl_for_core_types {
     ($($ty:ident)*) => {
         $(
             impl Reflect for $ty {
-                fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-                    <Self as DescribeType>::type_descriptor()
-                }
-
                 trivial_reflect_methods!();
 
                 fn patch(&mut self, value: &dyn Reflect) {
@@ -608,10 +608,6 @@ impl_for_core_types! {
 }
 
 impl Reflect for String {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        <Self as DescribeType>::type_descriptor()
-    }
-
     trivial_reflect_methods!();
 
     fn patch(&mut self, value: &dyn Reflect) {

--- a/crates/mirror-mirror/src/struct_.rs
+++ b/crates/mirror-mirror/src/struct_.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -17,7 +16,6 @@ use crate::Reflect;
 use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
-use crate::TypeDescriptor;
 use crate::Value;
 
 /// A reflected struct type.
@@ -73,18 +71,15 @@ impl StructValue {
     }
 }
 
-impl Reflect for StructValue {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl DescribeType for StructValue {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| {
-                    OpaqueNode::new::<Self>(Default::default(), graph)
-                })
-            }
-        }
-        <Self as DescribeType>::type_descriptor()
+impl DescribeType for StructValue {
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| {
+            OpaqueNode::new::<Self>(Default::default(), graph)
+        })
     }
+}
 
+impl Reflect for StructValue {
     trivial_reflect_methods!();
 
     fn patch(&mut self, value: &dyn Reflect) {

--- a/crates/mirror-mirror/src/tuple.rs
+++ b/crates/mirror-mirror/src/tuple.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::any::Any;
@@ -18,7 +17,6 @@ use crate::Reflect;
 use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
-use crate::TypeDescriptor;
 use crate::Value;
 
 /// A reflected tuple type.
@@ -85,18 +83,15 @@ impl Tuple for TupleValue {
     }
 }
 
-impl Reflect for TupleValue {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl DescribeType for TupleValue {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| {
-                    OpaqueNode::new::<Self>(Default::default(), graph)
-                })
-            }
-        }
-        <Self as DescribeType>::type_descriptor()
+impl DescribeType for TupleValue {
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| {
+            OpaqueNode::new::<Self>(Default::default(), graph)
+        })
     }
+}
 
+impl Reflect for TupleValue {
     trivial_reflect_methods!();
 
     fn patch(&mut self, value: &dyn Reflect) {
@@ -174,10 +169,6 @@ macro_rules! impl_tuple {
         where
             $($ident: Reflect + DescribeType + Clone,)*
         {
-            fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-                <Self as DescribeType>::type_descriptor()
-            }
-
             trivial_reflect_methods!();
 
             #[allow(unused_assignments)]

--- a/crates/mirror-mirror/src/tuple_struct.rs
+++ b/crates/mirror-mirror/src/tuple_struct.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::fmt;
@@ -16,7 +15,6 @@ use crate::ReflectMut;
 use crate::ReflectOwned;
 use crate::ReflectRef;
 use crate::Tuple;
-use crate::TypeDescriptor;
 use crate::Value;
 
 /// A reflected tuple struct type.
@@ -63,18 +61,15 @@ impl TupleStructValue {
     }
 }
 
-impl Reflect for TupleStructValue {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl DescribeType for TupleStructValue {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| {
-                    OpaqueNode::new::<Self>(Default::default(), graph)
-                })
-            }
-        }
-        <Self as DescribeType>::type_descriptor()
+impl DescribeType for TupleStructValue {
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| {
+            OpaqueNode::new::<Self>(Default::default(), graph)
+        })
     }
+}
 
+impl Reflect for TupleStructValue {
     trivial_reflect_methods!();
 
     fn patch(&mut self, value: &dyn Reflect) {

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
@@ -182,16 +181,16 @@ macro_rules! for_each_variant {
     };
 }
 
-impl Reflect for Value {
-    fn type_descriptor(&self) -> Cow<'static, TypeDescriptor> {
-        impl DescribeType for Value {
-            fn build(graph: &mut TypeGraph) -> NodeId {
-                graph.get_or_build_node_with::<Self, _>(|graph| {
-                    OpaqueNode::new::<Self>(Default::default(), graph)
-                })
-            }
-        }
+impl DescribeType for Value {
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| {
+            OpaqueNode::new::<Self>(Default::default(), graph)
+        })
+    }
+}
 
+impl Reflect for Value {
+    fn type_descriptor(&self) -> alloc::borrow::Cow<'static, TypeDescriptor> {
         <Self as DescribeType>::type_descriptor()
     }
 


### PR DESCRIPTION
We currently implement `DescribeType` for things inside the `Reflect::type_descriptor` method, for example [here](https://github.com/EmbarkStudios/mirror-mirror/blob/main/crates/mirror-mirror/src/foreign_impls/btree_map.rs#L79-L91). However in https://github.com/EmbarkStudios/mirror-mirror/pull/90 I moved that impl outside the method. I think that makes sense as its own PR though and makes https://github.com/EmbarkStudios/mirror-mirror/pull/90 a bit more focused.

This doesn't change any behavior, just moves some code around.