### PR TITLE
Make struct field iteration order consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Fix inconsistent ordering when iterating over fields in struct
+  values and struct types. Same for struct variants ([#98])
+
+[#98]: https://github.com/EmbarkStudios/mirror-mirror/pull/98
 
 # 0.1.5 (14. February, 2023)
 

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -643,9 +643,12 @@ impl<'a> StructType<'a> {
     }
 
     pub fn field_types(self) -> impl Iterator<Item = NamedField<'a>> {
-        self.node.fields.values().map(|node| NamedField {
-            node,
-            graph: self.graph,
+        self.node.field_names.iter().map(move |field_name| {
+            let node = self.node.fields.get(field_name).unwrap();
+            NamedField {
+                node,
+                graph: self.graph,
+            }
         })
     }
 
@@ -993,9 +996,12 @@ impl<'a> StructVariant<'a> {
     }
 
     pub fn field_types(self) -> impl Iterator<Item = NamedField<'a>> {
-        self.node.fields.values().map(|node| NamedField {
-            node,
-            graph: self.graph,
+        self.node.field_names.iter().map(|field_name| {
+            let node = self.node.fields.get(field_name).unwrap();
+            NamedField {
+                node,
+                graph: self.graph,
+            }
         })
     }
 


### PR DESCRIPTION
This took me all afternoon to find 😅 It caused issues in that internal system we have that starts with L and ends with X.

You can iterate over the fields in a struct either from a `&dyn Struct` or a `StructType` however the order was not consistent. When iterating over the fields in a value it used declaration order, whereas the type order was alphabetically. This fixes that so the type ordering is also based on the declaration.