### PR TITLE
Add `has_default_value` method to type descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add a `has_default_value` method to types in `type_info` ([#104])
+
+[#104]: https://github.com/EmbarkStudios/mirror-mirror/pull/104
 
 # 0.1.8 (23. February, 2023)
 

--- a/crates/mirror-mirror/src/tests/type_info.rs
+++ b/crates/mirror-mirror/src/tests/type_info.rs
@@ -1,6 +1,8 @@
 use core::any::type_name;
 use core::hash::Hash;
 
+use alloc::collections::BTreeMap;
+
 use crate::key_path;
 use crate::key_path::GetPath;
 use crate::tuple_struct::TupleStructValue;
@@ -195,6 +197,7 @@ fn opaque_default() {
     }
 
     let type_descriptor = Opaque::type_descriptor();
+
     let default_value = type_descriptor.default_value().unwrap();
 
     assert_eq!(default_value.get_at::<i32>(&key_path!(.0)).unwrap(), &1337);
@@ -266,4 +269,35 @@ fn basic_hash() {
 
     assert_eq!(foo_hash, foo_hash_2);
     assert_eq!(bar_hash, bar_hash_2);
+}
+
+#[test]
+fn has_default_value() {
+    #[derive(Reflect, Clone, Debug)]
+    #[reflect(crate_name(crate))]
+    struct A {
+        a: String,
+    }
+
+    #[derive(Reflect, Clone, Debug)]
+    #[reflect(crate_name(crate))]
+    struct B(String);
+
+    #[derive(Reflect, Clone, Debug)]
+    #[reflect(crate_name(crate))]
+    enum C {
+        C(i32),
+    }
+
+    assert!(<A as DescribeType>::type_descriptor().has_default_value());
+    assert!(<B as DescribeType>::type_descriptor().has_default_value());
+    assert!(<C as DescribeType>::type_descriptor().has_default_value());
+    assert!(<(i32, String) as DescribeType>::type_descriptor().has_default_value());
+    assert!(<[i32; 3] as DescribeType>::type_descriptor().has_default_value());
+    assert!(<BTreeMap<String, i32> as DescribeType>::type_descriptor().has_default_value());
+    assert!(<i32 as DescribeType>::type_descriptor().has_default_value());
+
+    // value doesn't have a default
+    assert!(!<[Value; 3] as DescribeType>::type_descriptor().has_default_value());
+    assert!(!<Value as DescribeType>::type_descriptor().has_default_value());
 }


### PR DESCRIPTION
We have a few places in our UI where we create a default value of some type when you click a button. This makes it cheaper to check if a type even has a default value, so you can show that in the UI before the user even clicks the button.

Previously your only option was to `.default_value().is_some()` which would build the whole data structure and likely do a bunch of allocations.