### PR TITLE
Add `with_capacity` constructors to `*Value` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `StructValue::with_capacity`,
+  `TupleStructValue::with_capacity`, and `TupleValue::with_capacity`
+- **added:** Add `EnumValue::new_struct_variant_with_capacity` and
+  `EnumValue::new_struct_variant_with_capacity` constructors
 
 # 0.1.8 (23. February, 2023)
 

--- a/crates/mirror-mirror-macros/Cargo.toml
+++ b/crates/mirror-mirror-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-mirror-macros"
-version = "0.1.0"
+version = "0.1.0" # remember to bump the version `mirror-mirror` depends on
 edition = "2021"
 authors = ["Embark <opensource@embark-studios.com>", "David Pedersen <david.pdrsn@gmail.com>"]
 repository = "https://github.com/EmbarkStudios/mirror-mirror"

--- a/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/enum_.rs
@@ -235,9 +235,11 @@ fn expand_reflect(
                         }
                     });
 
+                    let fields_len = fields.len();
+
                     quote! {
                         Self::#variant_ident { #(#field_names,)* } => {
-                            let mut value = EnumValue::new_struct_variant(#variant_ident_string);
+                            let mut value = EnumValue::new_struct_variant_with_capacity(#variant_ident_string, #fields_len);
                             #(#set_fields)*
                             value.finish().into()
                         }
@@ -251,9 +253,11 @@ fn expand_reflect(
                         .filter(filter_out_skipped)
                         .map(|field| &field.fake_ident);
 
+                    let fields_len = fields.len();
+
                     quote! {
                         Self::#variant_ident(#(#field_names,)*) => {
-                            let mut value = EnumValue::new_tuple_variant(#variant_ident_string);
+                            let mut value = EnumValue::new_tuple_variant_with_capacity(#variant_ident_string, #fields_len);
                             #(
                                 value.push_tuple_field(#included_fields.to_value());
                             )*

--- a/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/struct_named.rs
@@ -121,9 +121,11 @@ fn expand_reflect(
                 }
             });
 
+        let fields_len = fields.len();
+
         quote! {
             fn to_value(&self) -> Value {
-                let value = StructValue::default();
+                let value = StructValue::with_capacity(#fields_len);
                 #(#code_for_fields)*
                 value.into()
             }

--- a/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
+++ b/crates/mirror-mirror-macros/src/derive_reflect/tuple_struct.rs
@@ -123,9 +123,11 @@ fn expand_reflect(
                 }
             });
 
+        let fields_len = fields.len();
+
         quote! {
             fn to_value(&self) -> Value {
-                let value = TupleStructValue::default();
+                let value = TupleStructValue::with_capacity(#fields_len);
                 #(#code_for_fields)*
                 value.into()
             }

--- a/crates/mirror-mirror/src/enum_.rs
+++ b/crates/mirror-mirror/src/enum_.rs
@@ -80,19 +80,33 @@ enum EnumValueKind {
 
 impl EnumValue {
     pub fn new_struct_variant(name: impl Into<String>) -> StructVariantBuilder {
+        Self::new_struct_variant_with_capacity(name, 0)
+    }
+
+    pub fn new_struct_variant_with_capacity(
+        name: impl Into<String>,
+        capacity: usize,
+    ) -> StructVariantBuilder {
         StructVariantBuilder {
             inner: Self {
                 name: name.into(),
-                kind: EnumValueKind::Struct(Default::default()),
+                kind: EnumValueKind::Struct(StructValue::with_capacity(capacity)),
             },
         }
     }
 
     pub fn new_tuple_variant(name: impl Into<String>) -> TupleVariantBuilder {
+        Self::new_tuple_variant_with_capacity(name, 0)
+    }
+
+    pub fn new_tuple_variant_with_capacity(
+        name: impl Into<String>,
+        capacity: usize,
+    ) -> TupleVariantBuilder {
         TupleVariantBuilder {
             inner: Self {
                 name: name.into(),
-                kind: EnumValueKind::Tuple(Default::default()),
+                kind: EnumValueKind::Tuple(TupleValue::with_capacity(capacity)),
             },
         }
     }

--- a/crates/mirror-mirror/src/struct_.rs
+++ b/crates/mirror-mirror/src/struct_.rs
@@ -59,6 +59,14 @@ impl StructValue {
         Self::default()
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            field_names: Vec::with_capacity(capacity),
+            // there is no `BTreeMap::with_capacity` :(
+            fields: BTreeMap::new(),
+        }
+    }
+
     pub fn with_field(mut self, name: impl Into<String>, value: impl Into<Value>) -> Self {
         self.set_field(name, value);
         self

--- a/crates/mirror-mirror/src/tuple.rs
+++ b/crates/mirror-mirror/src/tuple.rs
@@ -50,6 +50,12 @@ impl TupleValue {
         Self::default()
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            fields: Vec::with_capacity(capacity),
+        }
+    }
+
     pub fn with_field(mut self, value: impl Into<Value>) -> Self {
         self.push_field(value);
         self

--- a/crates/mirror-mirror/src/tuple_struct.rs
+++ b/crates/mirror-mirror/src/tuple_struct.rs
@@ -50,6 +50,12 @@ impl TupleStructValue {
         Self::default()
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            tuple: TupleValue::with_capacity(capacity),
+        }
+    }
+
     pub fn with_field(self, value: impl Into<Value>) -> Self {
         Self {
             tuple: self.tuple.with_field(value),


### PR DESCRIPTION
Should hopefully reduce some resizes when calling `.to_value()`.