### PR TITLE
Remove `Reflect::type_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **breaking:** Remove `Reflect::type_descriptor` ([#90])
+- **breaking:** Remove `Reflect::type_id` ([#109])
 - **fixed:** Fully qualify `FromReflect` in generated code ([#107])
 
 [#90]: https://github.com/EmbarkStudios/mirror-mirror/pull/90
 [#107]: https://github.com/EmbarkStudios/mirror-mirror/pull/107
+[#109]: https://github.com/EmbarkStudios/mirror-mirror/pull/109
 
 # 0.1.9 (24. February, 2023)
 

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -262,7 +262,6 @@ use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::any::Any;
-use core::any::TypeId;
 use core::fmt;
 
 use crate::enum_::VariantField;
@@ -384,10 +383,35 @@ pub trait Reflect: Any + Send + 'static {
 
     fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<Self>()
-    }
-
+    /// Get the type name of the value.
+    ///
+    /// ```
+    /// use mirror_mirror::Reflect;
+    ///
+    /// fn dyn_reflect_type_name(value: &dyn Reflect) -> &str {
+    ///     value.type_name()
+    /// }
+    ///
+    /// assert_eq!(dyn_reflect_type_name(&1_i32), "i32");
+    /// ```
+    ///
+    /// Note that converting something into a [`Value`] will change what this method returns:
+    ///
+    /// ```
+    /// use mirror_mirror::Reflect;
+    ///
+    /// fn dyn_reflect_type_name(value: &dyn Reflect) -> &str {
+    ///     value.type_name()
+    /// }
+    ///
+    /// assert_eq!(
+    ///     dyn_reflect_type_name(&1_i32.to_value()),
+    ///     // the type name is no longer "i32"
+    ///     "mirror_mirror::value::Value",
+    /// );
+    /// ```
+    ///
+    /// If you want to keep the name of the original type use [`DescribeType::type_descriptor`].
     fn type_name(&self) -> &str {
         core::any::type_name::<Self>()
     }


### PR DESCRIPTION
Same reason removing `Reflect::type_descriptor` in #90.

I think keeping `type_name` is probably fine. Probably mostly used for pritning and (hopefully) not keys in maps or something. I've documented the footgun though.

A breaking change so this PR goes into the `v0.2.0` branch.