### PR TITLE
Make `KeyPath::pop` return the popped key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **breaking:** Remove `Reflect::type_descriptor` ([#90])
+- **breaking:** Make `KeyPath::pop` return the popped key ([#110])
 - **fixed:** Fully qualify `FromReflect` in generated code ([#107])
 - **added:** Implement `Reflect`, and friends, for `Infallible` ([#111])
 
 [#90]: https://github.com/EmbarkStudios/mirror-mirror/pull/90
 [#107]: https://github.com/EmbarkStudios/mirror-mirror/pull/107
 [#111]: https://github.com/EmbarkStudios/mirror-mirror/pull/111
+[#110]: https://github.com/EmbarkStudios/mirror-mirror/pull/110
 
 # 0.1.9 (24. February, 2023)
 

--- a/crates/mirror-mirror/src/key_path.rs
+++ b/crates/mirror-mirror/src/key_path.rs
@@ -262,8 +262,8 @@ impl KeyPath {
         self.path.is_empty()
     }
 
-    pub fn pop(&mut self) {
-        self.path.pop();
+    pub fn pop(&mut self) -> Option<Key> {
+        self.path.pop()
     }
 
     pub fn iter(&self) -> Iter<'_> {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Feels like an oversight that we don't return the popped key.