### PR TITLE
Require less strict `speedy` version

### DIFF
--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -25,7 +25,7 @@ mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
 ordered-float = { version = "3.4.0", default-features = false }
 serde = { version = "1.0.158", default-features = false, features = ["derive", "alloc"], optional = true }
-speedy = { version = "0.8.6", optional = true }
+speedy = { version = "0.8.5", optional = true }
 syn = { version = "2.0", features = ["full", "parsing"], optional = true }
 glam = { version = "0.22", optional = true }
 macaw = { version = "0.18", optional = true }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Due to some internal dependency clashes, I want to downgrade the minimum requirement of the `speedy` dependency. Any top-level user can still specify to use 0.8.6 as that is a non-breaking change.

