### PR TITLE
Use seed to generate predictable hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **change** Make use of deterministic hashes for `NodeId` and `TypeDescriptor`.
+- **change:** Make use of deterministic hashes for `NodeId` and `TypeDescriptor` ([#115])
+
+[#115]: https://github.com/EmbarkStudios/mirror-mirror/pull/115
 
 # 0.1.13 (29. March, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **change** Make use of deterministic hashes for `NodeId` and `TypeDescriptor`.
 
 # 0.1.13 (29. March, 2023)
 

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -367,6 +367,10 @@ pub use self::type_info::TypeDescriptor;
 #[doc(inline)]
 pub use self::value::Value;
 
+
+pub (crate) static STATIC_RANDOM_STATE: ahash::RandomState = ahash::RandomState::with_seeds(0x86c11a44c63f4f2f ,0xaf04d821054d02b3, 0x98f0a276c462acc1, 0xe2d6368e09c9c079);
+
+
 /// A reflected type.
 pub trait Reflect: Any + Send + 'static {
     fn type_descriptor(&self) -> Cow<'static, TypeDescriptor>;

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -367,9 +367,12 @@ pub use self::type_info::TypeDescriptor;
 #[doc(inline)]
 pub use self::value::Value;
 
-
-pub (crate) static STATIC_RANDOM_STATE: ahash::RandomState = ahash::RandomState::with_seeds(0x86c11a44c63f4f2f ,0xaf04d821054d02b3, 0x98f0a276c462acc1, 0xe2d6368e09c9c079);
-
+pub(crate) static STATIC_RANDOM_STATE: ahash::RandomState = ahash::RandomState::with_seeds(
+    0x86c11a44c63f4f2f,
+    0xaf04d821054d02b3,
+    0x98f0a276c462acc1,
+    0xe2d6368e09c9c079,
+);
 
 /// A reflected type.
 pub trait Reflect: Any + Send + 'static {

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -11,7 +11,7 @@ use core::ops::Deref;
 use super::*;
 use crate::Value;
 
-static HASHER_SEED: (u64, u64, u64, u64) = (23452345,569569, 344587659, 834993765);
+static HASHER_SEED: (u64, u64, u64, u64) = (0x86c11a44c63f4f2f ,0xaf04d821054d02b3, 0x98f0a276c462acc1, 0xe2d6368e09c9c079 );
 
 /// A `TypeGraph`'s node that refers to a specific type via its `TypeId'.
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Ord, Eq, Debug)]

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -5,10 +5,13 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::any::type_name;
 use core::any::TypeId;
+use core::hash::BuildHasher;
 use core::ops::Deref;
 
 use super::*;
 use crate::Value;
+
+static HASHER_SEED: (u64, u64, u64, u64) = (23452345,569569, 344587659, 834993765);
 
 /// A `TypeGraph`'s node that refers to a specific type via its `TypeId'.
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Ord, Eq, Debug)]
@@ -24,7 +27,9 @@ impl NodeId {
         use core::hash::Hash;
         use core::hash::Hasher;
 
-        let mut hasher = ahash::AHasher::default();
+        let random = ahash::RandomState::with_seeds(HASHER_SEED.0, HASHER_SEED.1, HASHER_SEED.2, HASHER_SEED.3);
+        let mut hasher = random.build_hasher();
+
         TypeId::of::<T>().hash(&mut hasher);
         Self(hasher.finish())
     }

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -9,6 +9,7 @@ use core::hash::BuildHasher;
 use core::ops::Deref;
 
 use super::*;
+use crate::STATIC_RANDOM_STATE;
 use crate::Value;
 
 /// A `TypeGraph`'s node that refers to a specific type via its `TypeId'.
@@ -25,7 +26,7 @@ impl NodeId {
         use core::hash::Hash;
         use core::hash::Hasher;
 
-        let mut hasher = RANDOM_STATE.build_hasher();
+        let mut hasher = STATIC_RANDOM_STATE.build_hasher();
         TypeId::of::<T>().hash(&mut hasher);
         Self(hasher.finish())
     }

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -11,8 +11,6 @@ use core::ops::Deref;
 use super::*;
 use crate::Value;
 
-static HASHER_SEED: (u64, u64, u64, u64) = (0x86c11a44c63f4f2f ,0xaf04d821054d02b3, 0x98f0a276c462acc1, 0xe2d6368e09c9c079 );
-
 /// A `TypeGraph`'s node that refers to a specific type via its `TypeId'.
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Ord, Eq, Debug)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
@@ -27,9 +25,7 @@ impl NodeId {
         use core::hash::Hash;
         use core::hash::Hasher;
 
-        let random = ahash::RandomState::with_seeds(HASHER_SEED.0, HASHER_SEED.1, HASHER_SEED.2, HASHER_SEED.3);
-        let mut hasher = random.build_hasher();
-
+        let mut hasher = RANDOM_STATE.build_hasher();
         TypeId::of::<T>().hash(&mut hasher);
         Self(hasher.finish())
     }

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -9,8 +9,8 @@ use core::hash::BuildHasher;
 use core::ops::Deref;
 
 use super::*;
-use crate::STATIC_RANDOM_STATE;
 use crate::Value;
+use crate::STATIC_RANDOM_STATE;
 
 /// A `TypeGraph`'s node that refers to a specific type via its `TypeId'.
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Ord, Eq, Debug)]

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -49,12 +49,16 @@ pub trait DescribeType: 'static {
 
             // a map required for generic types to have different type descriptors such as
             // `Vec<i32>` and `Vec<bool>`
-            static INFO: OnceBox<RwLock<HashMap<TypeId, &'static TypeDescriptor, ahash::RandomState>>> = OnceBox::new();
+            static INFO: OnceBox<
+                RwLock<HashMap<TypeId, &'static TypeDescriptor, ahash::RandomState>>,
+            > = OnceBox::new();
 
             let type_id = TypeId::of::<Self>();
 
             let lock = INFO.get_or_init(|| {
-                Box::from(RwLock::new(HashMap::with_hasher(STATIC_RANDOM_STATE.clone()))) // use seeded random state
+                Box::from(RwLock::new(HashMap::with_hasher(
+                    STATIC_RANDOM_STATE.clone(),
+                ))) // use seeded random state
             });
             if let Some(info) = lock.read().unwrap().get(&type_id) {
                 return Cow::Borrowed(info);

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -54,7 +54,7 @@ pub trait DescribeType: 'static {
             let type_id = TypeId::of::<Self>();
 
             let lock = INFO.get_or_init(|| {
-                Box::from(RwLock::new(HashMap::with_hasher(STATIC_RANDOM_STATE))) // use seeded random state
+                Box::from(RwLock::new(HashMap::with_hasher(STATIC_RANDOM_STATE.clone()))) // use seeded random state
             });
             if let Some(info) = lock.read().unwrap().get(&type_id) {
                 return Cow::Borrowed(info);


### PR DESCRIPTION
Specifies a constant seed that allows cross-process-deterministic hashes to be generated. 

Using this static random state in `HashMap` and the generation of `NodeId` allows this crate to generate predictable trees when serializing/deserializing encoding/decoding hashing.

See: https://docs.rs/ahash/latest/ahash/random_state/struct.RandomState.html

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/19969910/229842869-e4b32c23-1335-4af4-80ca-ae3c7c7d217f.png">

Currently, the hasher is seeded first time when the AHasher is constructed.

