### PR TITLE
Implement serialization traits for `ScalarOwned`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Implement serialization traits for `ScalarOwned`
 
 # 0.1.14 (11. April, 2023)
 

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -809,6 +809,8 @@ impl Clone for ReflectOwned {
 /// An owned reflected scalar type.
 #[derive(Debug, Clone)]
 #[allow(non_camel_case_types)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScalarOwned {
     usize(usize),
     u8(u8),


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I have a use case where I need to serialize just a scalar, so can't use `Value`
but `ScalarOwned` previously wasn't serializable.
