### PR TITLE
Disable clippy warning

### DIFF
--- a/crates/mirror-mirror/src/tests/meta.rs
+++ b/crates/mirror-mirror/src/tests/meta.rs
@@ -54,5 +54,6 @@ enum C {
     B(#[reflect(meta(n = 1))] String),
 
     #[reflect(meta(n = 1))]
+    #[allow(clippy::enum_variant_names)]
     C,
 }


### PR DESCRIPTION
Disable the clippy warning giving the below error:

> error: variant name ends with the enum's name
>   --> crates/mirror-mirror/src/tests/meta.rs:57:5
>   |
> 57 |     C,
>    |     ^
>    |
>   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
>  = note: `-D clippy::enum-variant-names` implied by `-D warnings`
>   = help: to override `-D warnings` add `#[allow(clippy::enum_variant_names)]`