### PR TITLE
Switch `no-std` CI build from `thumbv6m` to `thumbv7m`

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -66,8 +66,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - run: rustup target add thumbv6m-none-eabi
-      - run: cargo build --target thumbv6m-none-eabi --no-default-features
+      - run: rustup target add thumbv7m-none-eabi
+      - run: cargo build --target thumbv7m-none-eabi --no-default-features
 
   test:
     name: Test


### PR DESCRIPTION
As shown by `rustc --target=thumbv6m-none-eabi --print=cfg`, the `thumbv6m-none-eabi` target does not have `target_has_atomic = "ptr"`, so `portable-atomics` (which `once_cell` switched to in `0.19`) does not provide `AtomicPtr::compare_exchange`, which is necessary for the build.

Switch to `thumbv7m-none-eabi` instead, which is still a `no_std` target: https://doc.rust-lang.org/nightly/rustc/platform-support.html

Fixes the CI error:

> error[E0599]: no method named compare_exchange found for struct portable_atomic::AtomicPtr in the current scope