### PR TITLE
Improve `Array`, `List`, and `Map` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Iterating over fields and variants in type descriptors is now done
   in the same order as defined in the code ([#119])
 - **fixed:** Support derive reflect for `HashMap` ([#119])
+- **breaking:** Add `Array::swap` ([#136])
+- **breaking:** Add `List::try_insert` ([#136])
+- **breaking:** `List::push` renamed to `List::try_push` ([#136])
+- **breaking:** `Map::insert` renamed to `Map::try_insert` ([#136])
+- **breaking:** `Map::remove` renamed to `Map::try_remove` ([#136])
 
 [#90]: https://github.com/EmbarkStudios/mirror-mirror/pull/90
 [#110]: https://github.com/EmbarkStudios/mirror-mirror/pull/110
 [#109]: https://github.com/EmbarkStudios/mirror-mirror/pull/109
 [#119]: https://github.com/EmbarkStudios/mirror-mirror/pull/119
+[#136]: https://github.com/EmbarkStudios/mirror-mirror/pull/136
 
 # 0.1.19 (26. February, 2023)
 

--- a/crates/mirror-mirror/src/array.rs
+++ b/crates/mirror-mirror/src/array.rs
@@ -17,6 +17,13 @@ pub trait Array: Reflect {
     fn iter(&self) -> Iter<'_>;
 
     fn iter_mut(&mut self) -> ValueIterMut<'_>;
+
+    /// Swaps two elements in the array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` or `b` are out of bounds.
+    fn swap(&mut self, a: usize, b: usize);
 }
 
 impl fmt::Debug for dyn Array {

--- a/crates/mirror-mirror/src/foreign_impls/array.rs
+++ b/crates/mirror-mirror/src/foreign_impls/array.rs
@@ -101,6 +101,10 @@ where
             .map(|value| value.as_reflect_mut());
         Box::new(iter)
     }
+
+    fn swap(&mut self, a: usize, b: usize) {
+        self.as_mut_slice().swap(a, b);
+    }
 }
 
 impl<T, const N: usize> FromReflect for [T; N]

--- a/crates/mirror-mirror/src/foreign_impls/btree_map.rs
+++ b/crates/mirror-mirror/src/foreign_impls/btree_map.rs
@@ -4,6 +4,7 @@ use core::any::Any;
 use core::fmt;
 
 use crate::iter::PairIterMut;
+use crate::map::MapError;
 use crate::type_info::graph::MapNode;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -21,52 +22,7 @@ where
     K: FromReflect + DescribeType + Ord,
     V: FromReflect + DescribeType,
 {
-    fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get(&key)?;
-        Some(value.as_reflect())
-    }
-
-    fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get_mut(&key)?;
-        Some(value.as_reflect_mut())
-    }
-
-    fn insert(&mut self, key: &dyn Reflect, value: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let value = V::from_reflect(value)?;
-        let previous = BTreeMap::insert(self, key, value)?;
-        Some(Box::new(previous))
-    }
-
-    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let previous = BTreeMap::remove(self, &key)?;
-        Some(Box::new(previous))
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
-
-    fn iter(&self) -> crate::map::Iter<'_> {
-        let iter = self
-            .iter()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect()));
-        Box::new(iter)
-    }
-
-    fn iter_mut(&mut self) -> PairIterMut<'_, dyn Reflect> {
-        let iter = self
-            .iter_mut()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect_mut()));
-        Box::new(iter)
-    }
+    map_methods!();
 }
 
 impl<K, V> DescribeType for BTreeMap<K, V>

--- a/crates/mirror-mirror/src/foreign_impls/hash_map.rs
+++ b/crates/mirror-mirror/src/foreign_impls/hash_map.rs
@@ -8,6 +8,7 @@ use core::hash::Hash;
 use std::collections::HashMap;
 
 use crate::iter::PairIterMut;
+use crate::map::MapError;
 use crate::type_info::graph::MapNode;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -105,52 +106,7 @@ where
     V: FromReflect + DescribeType,
     S: Default + BuildHasher + Send + 'static,
 {
-    fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get(&key)?;
-        Some(value.as_reflect())
-    }
-
-    fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get_mut(&key)?;
-        Some(value.as_reflect_mut())
-    }
-
-    fn insert(&mut self, key: &dyn Reflect, value: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let value = V::from_reflect(value)?;
-        let previous = self.insert(key, value)?;
-        Some(Box::new(previous))
-    }
-
-    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let previous = self.remove(&key)?;
-        Some(Box::new(previous))
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
-
-    fn iter(&self) -> crate::map::Iter<'_> {
-        let iter = self
-            .iter()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect()));
-        Box::new(iter)
-    }
-
-    fn iter_mut(&mut self) -> PairIterMut<'_, dyn Reflect> {
-        let iter = self
-            .iter_mut()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect_mut()));
-        Box::new(iter)
-    }
+    map_methods!();
 }
 
 impl<K, V, S> DescribeType for HashMap<K, V, S>

--- a/crates/mirror-mirror/src/foreign_impls/kollect/linear_map.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/linear_map.rs
@@ -4,6 +4,7 @@ use core::fmt;
 use kollect::LinearMap;
 
 use crate::iter::PairIterMut;
+use crate::map::MapError;
 use crate::type_info::graph::MapNode;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -98,52 +99,7 @@ where
     K: FromReflect + DescribeType + Eq,
     V: FromReflect + DescribeType,
 {
-    fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get(&key)?;
-        Some(value.as_reflect())
-    }
-
-    fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get_mut(&key)?;
-        Some(value.as_reflect_mut())
-    }
-
-    fn insert(&mut self, key: &dyn Reflect, value: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let value = V::from_reflect(value)?;
-        let previous = self.insert(key, value)?;
-        Some(Box::new(previous))
-    }
-
-    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let previous = self.remove(&key)?;
-        Some(Box::new(previous))
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
-
-    fn iter(&self) -> crate::map::Iter<'_> {
-        let iter = self
-            .iter()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect()));
-        Box::new(iter)
-    }
-
-    fn iter_mut(&mut self) -> PairIterMut<'_, dyn Reflect> {
-        let iter = self
-            .iter_mut()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect_mut()));
-        Box::new(iter)
-    }
+    map_methods!();
 }
 
 impl<K, V> DescribeType for LinearMap<K, V>

--- a/crates/mirror-mirror/src/foreign_impls/kollect/ordered_map.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/ordered_map.rs
@@ -6,6 +6,7 @@ use core::hash::Hash;
 use kollect::OrderedMap;
 
 use crate::iter::PairIterMut;
+use crate::map::MapError;
 use crate::type_info::graph::MapNode;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -103,52 +104,7 @@ where
     V: FromReflect + DescribeType,
     S: Default + BuildHasher + Send + 'static,
 {
-    fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get(&key)?;
-        Some(value.as_reflect())
-    }
-
-    fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get_mut(&key)?;
-        Some(value.as_reflect_mut())
-    }
-
-    fn insert(&mut self, key: &dyn Reflect, value: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let value = V::from_reflect(value)?;
-        let previous = self.insert(key, value)?;
-        Some(Box::new(previous))
-    }
-
-    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let previous = self.remove(&key)?;
-        Some(Box::new(previous))
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
-
-    fn iter(&self) -> crate::map::Iter<'_> {
-        let iter = self
-            .iter()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect()));
-        Box::new(iter)
-    }
-
-    fn iter_mut(&mut self) -> PairIterMut<'_, dyn Reflect> {
-        let iter = self
-            .iter_mut()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect_mut()));
-        Box::new(iter)
-    }
+    map_methods!();
 }
 
 impl<K, V, S> DescribeType for OrderedMap<K, V, S>

--- a/crates/mirror-mirror/src/foreign_impls/kollect/unordered_map.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/unordered_map.rs
@@ -6,6 +6,7 @@ use core::hash::Hash;
 use kollect::UnorderedMap;
 
 use crate::iter::PairIterMut;
+use crate::map::MapError;
 use crate::type_info::graph::MapNode;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -103,52 +104,7 @@ where
     V: FromReflect + DescribeType,
     S: Default + BuildHasher + Send + 'static,
 {
-    fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get(&key)?;
-        Some(value.as_reflect())
-    }
-
-    fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
-        let key = K::from_reflect(key)?;
-        let value = self.get_mut(&key)?;
-        Some(value.as_reflect_mut())
-    }
-
-    fn insert(&mut self, key: &dyn Reflect, value: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let value = V::from_reflect(value)?;
-        let previous = self.insert(key, value)?;
-        Some(Box::new(previous))
-    }
-
-    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let key = K::from_reflect(key)?;
-        let previous = self.remove(&key)?;
-        Some(Box::new(previous))
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
-
-    fn iter(&self) -> crate::map::Iter<'_> {
-        let iter = self
-            .iter()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect()));
-        Box::new(iter)
-    }
-
-    fn iter_mut(&mut self) -> PairIterMut<'_, dyn Reflect> {
-        let iter = self
-            .iter_mut()
-            .map(|(key, value)| (key.as_reflect(), value.as_reflect_mut()));
-        Box::new(iter)
-    }
+    map_methods!();
 }
 
 impl<K, V, S> DescribeType for UnorderedMap<K, V, S>

--- a/crates/mirror-mirror/src/foreign_impls/vec.rs
+++ b/crates/mirror-mirror/src/foreign_impls/vec.rs
@@ -4,6 +4,7 @@ use core::any::Any;
 
 use crate::array::Array;
 use crate::iter::ValueIterMut;
+use crate::list::ListError;
 use crate::type_info::graph::ListNode;
 use crate::type_info::graph::NodeId;
 use crate::type_info::graph::TypeGraph;
@@ -20,9 +21,12 @@ impl<T> List for Vec<T>
 where
     T: FromReflect + DescribeType,
 {
-    fn push(&mut self, value: &dyn Reflect) {
-        if let Some(value) = T::from_reflect(value) {
+    fn try_push(&mut self, element: &dyn Reflect) -> Result<(), ListError> {
+        if let Some(value) = T::from_reflect(element) {
             Vec::push(self, value);
+            Ok(())
+        } else {
+            Err(ListError)
         }
     }
 
@@ -37,6 +41,15 @@ where
             Some(Box::new(value))
         } else {
             None
+        }
+    }
+
+    fn try_insert(&mut self, index: usize, element: &dyn Reflect) -> Result<(), ListError> {
+        if let Some(element) = T::from_reflect(element) {
+            Vec::insert(self, index, element);
+            Ok(())
+        } else {
+            Err(ListError)
         }
     }
 }
@@ -73,6 +86,10 @@ where
             .iter_mut()
             .map(|value| value.as_reflect_mut());
         Box::new(iter)
+    }
+
+    fn swap(&mut self, a: usize, b: usize) {
+        self.as_mut_slice().swap(a, b);
     }
 }
 

--- a/crates/mirror-mirror/src/list.rs
+++ b/crates/mirror-mirror/src/list.rs
@@ -6,11 +6,27 @@ use crate::Reflect;
 
 /// A reflected list type.
 pub trait List: Array {
-    fn push(&mut self, value: &dyn Reflect);
+    /// Appends an element to the back of a collection.
+    ///
+    /// Returns `Err(_)` if `element` couldn't be parsed to the element type, using
+    /// `FromReflect::from_reflect`.
+    fn try_push(&mut self, element: &dyn Reflect) -> Result<(), ListError>;
 
+    /// Removes the last element from a vector and returns it, or `None` if it is empty.
     fn pop(&mut self) -> Option<Box<dyn Reflect>>;
 
+    /// Removes and returns the element at position `index` within the vector, shifting all elements
+    /// after it to the left.
+    ///
+    /// Returns `None` if `inde` is out of bounds.
     fn try_remove(&mut self, index: usize) -> Option<Box<dyn Reflect>>;
+
+    /// Inserts an element at position `index` within the vector, shifting all elements after it to
+    /// the right.
+    ///
+    /// Returns `Err(_)` if `element` couldn't be parsed to the element type, using
+    /// `FromReflect::from_reflect`.
+    fn try_insert(&mut self, index: usize, element: &dyn Reflect) -> Result<(), ListError>;
 }
 
 impl fmt::Debug for dyn List {
@@ -18,3 +34,16 @@ impl fmt::Debug for dyn List {
         self.as_reflect().debug(f)
     }
 }
+
+/// A method on a reflected list failed.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct ListError;
+
+impl core::fmt::Display for ListError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to parse element")
+    }
+}
+
+impl std::error::Error for ListError {}

--- a/crates/mirror-mirror/src/tests/map.rs
+++ b/crates/mirror-mirror/src/tests/map.rs
@@ -193,6 +193,9 @@ fn exoctic_value_type() {
     let foo_default_value = <Foo as DescribeType>::type_descriptor()
         .default_value()
         .unwrap();
-    map.as_map_mut().unwrap().insert(&1, &foo_default_value);
+    map.as_map_mut()
+        .unwrap()
+        .try_insert(&1, &foo_default_value)
+        .unwrap();
     assert_eq!(map.len(), 1);
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Pass over methods on `Array`, `List`, and `Map` that makes things more explicit and adds a few new useful methods:
- Add `Array::swap`
- Add `List::try_insert`
- `List::push` renamed to `List::try_push` and now returns a result indicating that `FromReflect::from_reflect` failed
- `Map::insert` renamed to `Map::try_insert` and also returns result
- `Map::remove` renamed to `Map::try_remove` and also returns result

Also deduplicated the `Map` impls.

### Related Issues

- Fixes https://github.com/EmbarkStudios/mirror-mirror/issues/132