### PR TITLE
Ensure  backwards compatible serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +140,24 @@ dependencies = [
  "glam",
  "kollect",
  "macaw",
- "mirror-mirror-macros",
+ "mirror-mirror 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirror-mirror-macros 0.1.4",
+ "once_cell",
+ "ordered-float",
+ "ron",
+ "serde",
+ "speedy",
+ "syn",
+]
+
+[[package]]
+name = "mirror-mirror"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14e8dc2bf56db79766cf6438a1bfb33047af85a439809550101dabcd1c0c42b"
+dependencies = [
+ "ahash",
+ "mirror-mirror-macros 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "ordered-float",
  "serde",
@@ -138,7 +170,18 @@ name = "mirror-mirror-macros"
 version = "0.1.4"
 dependencies = [
  "kollect",
- "mirror-mirror",
+ "mirror-mirror 0.1.19",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mirror-mirror-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873a8136d73249ded007bc60b4a2e0fc44558469e622f86a84e906361fb79131"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -195,6 +238,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -31,6 +31,10 @@ syn = { version = "2.0", features = ["full", "parsing"], optional = true }
 glam = { version = ">= 0.22, <= 0.25", optional = true }
 macaw = { version = "0.19", optional = true }
 
+[dev-dependencies]
+mirror-mirror-1 = { package = "mirror-mirror", version = "0.1" }
+ron = "0.8.1"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/mirror-mirror/src/tests/struct_.rs
+++ b/crates/mirror-mirror/src/tests/struct_.rs
@@ -67,7 +67,7 @@ fn from_reflect() {
     let foo = Foo::default();
     let foo_reflect: &dyn Reflect = &foo;
 
-    let foo = Foo::from_reflect(foo_reflect).unwrap();
+    let foo = <Foo as FromReflect>::from_reflect(foo_reflect).unwrap();
 
     assert_eq!(foo.field, 0);
 }
@@ -129,7 +129,7 @@ fn box_dyn_reflect_as_reflect() {
         &42,
     );
 
-    let foo = Foo::from_reflect(box_dyn_reflect.as_reflect()).unwrap();
+    let foo = <Foo as FromReflect>::from_reflect(box_dyn_reflect.as_reflect()).unwrap();
     assert_eq!(foo, Foo { field: 42 });
 }
 

--- a/crates/mirror-mirror/src/tests/struct_.rs
+++ b/crates/mirror-mirror/src/tests/struct_.rs
@@ -366,6 +366,13 @@ fn deserialize_old_struct() {
     let v2_type_descriptor =
         ron::from_str::<Cow<'static, crate::type_info::TypeDescriptor>>(&v1_ron).unwrap();
 
-    let name_type = v2_type_descriptor.as_struct().unwrap().field_type("n").unwrap().get_type().as_scalar().unwrap();
+    let name_type = v2_type_descriptor
+        .as_struct()
+        .unwrap()
+        .field_type("n")
+        .unwrap()
+        .get_type()
+        .as_scalar()
+        .unwrap();
     assert!(matches!(name_type, crate::type_info::ScalarType::i32));
 }

--- a/crates/mirror-mirror/src/tests/struct_.rs
+++ b/crates/mirror-mirror/src/tests/struct_.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -327,4 +329,43 @@ fn consistent_iteration_order_of_struct_variant_fields() {
     }
 
     assert_eq!(by_value, by_type);
+}
+
+#[test]
+fn deserialize_old_struct() {
+    mod v1 {
+        #[derive(mirror_mirror_1::Reflect, Debug, Clone)]
+        #[reflect(crate_name(mirror_mirror_1))]
+        pub struct Foo {
+            pub n: i32,
+        }
+    }
+
+    mod v2 {
+        #[derive(crate::Reflect, Debug, Clone)]
+        #[reflect(crate_name(crate))]
+        pub struct Foo {
+            pub n: i32,
+        }
+    }
+
+    // deserializing value
+    let n = 123;
+    let v1_foo = mirror_mirror_1::Reflect::to_value(&v1::Foo { n });
+    let v1_ron = ron::to_string(&v1_foo).unwrap();
+
+    let v2_value = ron::from_str::<crate::Value>(&v1_ron).unwrap();
+    let v2_foo = <v2::Foo as crate::FromReflect>::from_reflect(&v2_value).unwrap();
+
+    assert_eq!(n, v2_foo.n);
+
+    // deserializing type descriptor
+    let v1_type_descriptor = <v1::Foo as mirror_mirror_1::DescribeType>::type_descriptor();
+    let v1_ron = ron::to_string(&v1_type_descriptor).unwrap();
+
+    let v2_type_descriptor =
+        ron::from_str::<Cow<'static, crate::type_info::TypeDescriptor>>(&v1_ron).unwrap();
+
+    let name_type = v2_type_descriptor.as_struct().unwrap().field_type("n").unwrap().get_type().as_scalar().unwrap();
+    assert!(matches!(name_type, crate::type_info::ScalarType::i32));
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I was under the impression https://github.com/EmbarkStudios/mirror-mirror/pull/119 was a breaking change to how we serialized struct values, but upon further inspection that doesn't seem to be the case!

Just for good measure this adds a test that ensures 0.2 remain backwards compatible with 0.1