### PR TITLE
Support reflecting sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `Map::insert` renamed to `Map::try_insert` ([#136])
 - **breaking:** `Map::remove` renamed to `Map::try_remove` ([#136])
 - **breaking:** Update to kollect 0.3 ([#138])
+- **breaking:** Add reflected sets ([#140])
 
 [#90]: https://github.com/EmbarkStudios/mirror-mirror/pull/90
 [#110]: https://github.com/EmbarkStudios/mirror-mirror/pull/110
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#119]: https://github.com/EmbarkStudios/mirror-mirror/pull/119
 [#136]: https://github.com/EmbarkStudios/mirror-mirror/pull/136
 [#138]: https://github.com/EmbarkStudios/mirror-mirror/pull/138
+[#140]: https://github.com/EmbarkStudios/mirror-mirror/pull/140
 
 # 0.1.19 (26. February, 2023)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "kollect"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b152467962ad3dd6b1f0c6c4c1e453c7bbaff3d02d19180dec658e2f3fc1e804"
+checksum = "149a6226dcaffb051e49418fd3b7e2e19814688c4cabfeddbe64b0dd0767e489"
 dependencies = [
  "ahash",
  "indexmap",

--- a/crates/mirror-mirror-macros/Cargo.toml
+++ b/crates/mirror-mirror-macros/Cargo.toml
@@ -13,7 +13,7 @@ description = "Macros for the mirror-mirror crate"
 proc-macro = true
 
 [dependencies]
-kollect = { version = "0.3", default-features = false }
+kollect = { version = "0.3.2", default-features = false }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
 syn = { version = "2.0.2", features = ["full", "parsing", "visit"] }

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -21,7 +21,7 @@ macaw = ["dep:macaw"]
 
 [dependencies]
 ahash = { version = "0.8.2", default-features = false, features = ["runtime-rng"] }
-kollect = { version = "0.3", default-features = false }
+kollect = { version = "0.3.2", default-features = false }
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
 ordered-float = { version = "4", default-features = false }

--- a/crates/mirror-mirror/src/foreign_impls/kollect/mod.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/mod.rs
@@ -1,6 +1,7 @@
 mod linear_map;
 mod ordered_map;
 mod unordered_map;
+
+mod linear_set;
+mod ordered_set;
 mod unordered_set;
-// mod ordered_set;
-// mod linear_set;

--- a/crates/mirror-mirror/src/foreign_impls/kollect/mod.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/mod.rs
@@ -1,3 +1,6 @@
 mod linear_map;
 mod ordered_map;
 mod unordered_map;
+mod unordered_set;
+// mod ordered_set;
+// mod linear_set;

--- a/crates/mirror-mirror/src/foreign_impls/kollect/ordered_set.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/ordered_set.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use core::hash::Hash;
 use std::hash::BuildHasher;
 
-use kollect::UnorderedSet;
+use kollect::OrderedSet;
 
 use crate::{
     set::{Iter, SetError},
@@ -11,7 +11,7 @@ use crate::{
     DescribeType, FromReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, Set, Value,
 };
 
-impl<V, S> Reflect for UnorderedSet<V, S>
+impl<V, S> Reflect for OrderedSet<V, S>
 where
     V: FromReflect + DescribeType + Hash + Eq,
     S: Default + BuildHasher + Send + 'static,
@@ -54,7 +54,7 @@ where
     }
 }
 
-impl<V, S> FromReflect for UnorderedSet<V, S>
+impl<V, S> FromReflect for OrderedSet<V, S>
 where
     V: FromReflect + DescribeType + Eq + Hash,
     S: Default + BuildHasher + Send + 'static,
@@ -62,7 +62,7 @@ where
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
         let set = reflect.as_set()?;
         let len = set.len();
-        let mut out = UnorderedSet::with_capacity_and_hasher(len, S::default());
+        let mut out = OrderedSet::with_capacity_and_hasher(len, S::default());
         for element in set.iter() {
             out.insert(V::from_reflect(element)?);
         }
@@ -70,17 +70,17 @@ where
     }
 }
 
-impl<V> From<UnorderedSet<V>> for Value
+impl<V> From<OrderedSet<V>> for Value
 where
     V: Reflect,
 {
-    fn from(set: UnorderedSet<V>) -> Self {
+    fn from(set: OrderedSet<V>) -> Self {
         let set = set.into_iter().map(|element| element.to_value()).collect();
         Value::Set(set)
     }
 }
 
-impl<V, S> Set for UnorderedSet<V, S>
+impl<V, S> Set for OrderedSet<V, S>
 where
     V: FromReflect + DescribeType + Eq + Hash,
     S: Default + BuildHasher + Send + 'static,
@@ -88,7 +88,7 @@ where
     set_methods!();
 }
 
-impl<V, S> DescribeType for UnorderedSet<V, S>
+impl<V, S> DescribeType for OrderedSet<V, S>
 where
     V: DescribeType,
     S: 'static,

--- a/crates/mirror-mirror/src/foreign_impls/kollect/unordered_set.rs
+++ b/crates/mirror-mirror/src/foreign_impls/kollect/unordered_set.rs
@@ -1,0 +1,99 @@
+use core::any::Any;
+use core::fmt;
+use core::hash::Hash;
+use std::hash::BuildHasher;
+
+use kollect::UnorderedSet;
+
+use crate::{
+    set::{Iter, SetError},
+    type_info::graph::{NodeId, SetNode, TypeGraph},
+    DescribeType, FromReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, Set, Value,
+};
+
+impl<V, S> Reflect for UnorderedSet<V, S>
+where
+    V: FromReflect + DescribeType + Hash + Eq,
+    S: Default + BuildHasher + Send + 'static,
+{
+    trivial_reflect_methods!();
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Set(self)
+    }
+
+    fn reflect_ref(&self) -> ReflectRef<'_> {
+        ReflectRef::Set(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
+        ReflectMut::Set(self)
+    }
+
+    /// Performs a union.
+    fn patch(&mut self, value: &dyn Reflect) {
+        if let Some(set) = value.as_set() {
+            for element in set.iter() {
+                _ = self.try_insert(element);
+            }
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        let data = self.iter().map(Reflect::to_value).collect();
+        Value::Set(data)
+    }
+
+    fn clone_reflect(&self) -> Box<dyn Reflect> {
+        let value = self.to_value();
+        Box::new(Self::from_reflect(&value).unwrap())
+    }
+
+    fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(Set::iter(self)).finish()
+    }
+}
+
+impl<V, S> FromReflect for UnorderedSet<V, S>
+where
+    V: FromReflect + DescribeType + Eq + Hash,
+    S: Default + BuildHasher + Send + 'static,
+{
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+        let set = reflect.as_set()?;
+        let len = set.len();
+        let mut out = UnorderedSet::with_capacity_and_hasher(len, S::default());
+        for element in set.iter() {
+            out.insert(V::from_reflect(element)?);
+        }
+        Some(out)
+    }
+}
+
+impl<V> From<UnorderedSet<V>> for Value
+where
+    V: Reflect,
+{
+    fn from(set: UnorderedSet<V>) -> Self {
+        let map = set.into_iter().map(|element| element.to_value()).collect();
+        Value::Set(map)
+    }
+}
+
+impl<V, S> Set for UnorderedSet<V, S>
+where
+    V: FromReflect + DescribeType + Eq + Hash,
+    S: Default + BuildHasher + Send + 'static,
+{
+    set_methods!();
+}
+
+impl<V, S> DescribeType for UnorderedSet<V, S>
+where
+    V: DescribeType,
+    S: 'static,
+{
+    fn build(graph: &mut TypeGraph) -> NodeId {
+        graph.get_or_build_node_with::<Self, _>(|graph| SetNode::new::<Self, V>(graph))
+    }
+}

--- a/crates/mirror-mirror/src/get_field.rs
+++ b/crates/mirror-mirror/src/get_field.rs
@@ -52,6 +52,7 @@ impl<'a> GetField<'a, &str, private::Value> for &'a Value {
             | ReflectRef::Tuple(_)
             | ReflectRef::List(_)
             | ReflectRef::Array(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Opaque(_)
             | ReflectRef::Scalar(_) => None,
         }
@@ -71,6 +72,7 @@ impl<'a> GetFieldMut<'a, &str, private::Value> for &'a mut Value {
             | ReflectMut::Tuple(_)
             | ReflectMut::List(_)
             | ReflectMut::Array(_)
+            | ReflectMut::Set(_)
             | ReflectMut::Opaque(_)
             | ReflectMut::Scalar(_) => None,
         }
@@ -93,7 +95,10 @@ where
                 ReflectRef::Array(inner) => inner.get_field(key),
                 ReflectRef::List(inner) => inner.get_field(key),
                 ReflectRef::Map(inner) => inner.get_field(key),
-                ReflectRef::Struct(_) | ReflectRef::Scalar(_) | ReflectRef::Opaque(_) => None,
+                ReflectRef::Struct(_)
+                | ReflectRef::Set(_)
+                | ReflectRef::Scalar(_)
+                | ReflectRef::Opaque(_) => None,
             }
         } else if let Some(key) = key.as_any().downcast_ref::<String>() {
             match self.reflect_ref() {
@@ -104,6 +109,7 @@ where
                 | ReflectRef::Enum(_)
                 | ReflectRef::List(_)
                 | ReflectRef::Array(_)
+                | ReflectRef::Set(_)
                 | ReflectRef::Opaque(_)
                 | ReflectRef::Scalar(_) => None,
             }
@@ -115,6 +121,7 @@ where
                 | ReflectRef::Enum(_)
                 | ReflectRef::Array(_)
                 | ReflectRef::List(_)
+                | ReflectRef::Set(_)
                 | ReflectRef::Struct(_)
                 | ReflectRef::Opaque(_)
                 | ReflectRef::Scalar(_) => None,
@@ -139,7 +146,10 @@ where
                 ReflectMut::List(inner) => inner.get_field_mut(key),
                 ReflectMut::Array(inner) => inner.get_field_mut(key),
                 ReflectMut::Map(inner) => inner.get_field_mut(key),
-                ReflectMut::Struct(_) | ReflectMut::Scalar(_) | ReflectMut::Opaque(_) => None,
+                ReflectMut::Struct(_)
+                | ReflectMut::Set(_)
+                | ReflectMut::Scalar(_)
+                | ReflectMut::Opaque(_) => None,
             }
         } else if let Some(key) = key.as_any().downcast_ref::<String>() {
             match self.reflect_mut() {
@@ -150,6 +160,7 @@ where
                 | ReflectMut::Enum(_)
                 | ReflectMut::List(_)
                 | ReflectMut::Array(_)
+                | ReflectMut::Set(_)
                 | ReflectMut::Opaque(_)
                 | ReflectMut::Scalar(_) => None,
             }
@@ -161,6 +172,7 @@ where
                 | ReflectMut::Enum(_)
                 | ReflectMut::List(_)
                 | ReflectMut::Array(_)
+                | ReflectMut::Set(_)
                 | ReflectMut::Struct(_)
                 | ReflectMut::Opaque(_)
                 | ReflectMut::Scalar(_) => None,

--- a/crates/mirror-mirror/src/key_path.rs
+++ b/crates/mirror-mirror/src/key_path.rs
@@ -62,6 +62,7 @@ where
                     | ReflectRef::Tuple(_)
                     | ReflectRef::Array(_)
                     | ReflectRef::List(_)
+                    | ReflectRef::Set(_)
                     | ReflectRef::Map(_)
                     | ReflectRef::Scalar(_)
                     | ReflectRef::Opaque(_) => return None,
@@ -78,6 +79,7 @@ where
                     | ReflectRef::Struct(_)
                     | ReflectRef::Array(_)
                     | ReflectRef::List(_)
+                    | ReflectRef::Set(_)
                     | ReflectRef::Scalar(_)
                     | ReflectRef::Opaque(_) => return None,
                 },
@@ -90,6 +92,7 @@ where
                     | ReflectRef::TupleStruct(_)
                     | ReflectRef::Tuple(_)
                     | ReflectRef::Enum(_)
+                    | ReflectRef::Set(_)
                     | ReflectRef::Scalar(_)
                     | ReflectRef::Opaque(_) => return None,
                 },
@@ -108,6 +111,7 @@ where
                     | ReflectRef::List(_)
                     | ReflectRef::Array(_)
                     | ReflectRef::Map(_)
+                    | ReflectRef::Set(_)
                     | ReflectRef::Opaque(_)
                     | ReflectRef::Scalar(_) => return None,
                 },
@@ -150,6 +154,7 @@ where
                     | ReflectMut::Array(_)
                     | ReflectMut::List(_)
                     | ReflectMut::Map(_)
+                    | ReflectMut::Set(_)
                     | ReflectMut::Scalar(_)
                     | ReflectMut::Opaque(_) => return None,
                 },
@@ -165,6 +170,7 @@ where
                     | ReflectMut::Struct(_)
                     | ReflectMut::Array(_)
                     | ReflectMut::List(_)
+                    | ReflectMut::Set(_)
                     | ReflectMut::Scalar(_)
                     | ReflectMut::Opaque(_) => return None,
                 },
@@ -177,6 +183,7 @@ where
                     | ReflectMut::TupleStruct(_)
                     | ReflectMut::Tuple(_)
                     | ReflectMut::Enum(_)
+                    | ReflectMut::Set(_)
                     | ReflectMut::Scalar(_)
                     | ReflectMut::Opaque(_) => return None,
                 },
@@ -195,6 +202,7 @@ where
                     | ReflectMut::List(_)
                     | ReflectMut::Array(_)
                     | ReflectMut::Map(_)
+                    | ReflectMut::Set(_)
                     | ReflectMut::Opaque(_)
                     | ReflectMut::Scalar(_) => return None,
                 },
@@ -588,6 +596,7 @@ pub(crate) fn value_to_usize(value: &Value) -> Option<usize> {
         | Value::TupleStructValue(_)
         | Value::TupleValue(_)
         | Value::List(_)
+        | Value::Set(_)
         | Value::Map(_) => None,
     }
 }

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -344,6 +344,38 @@ macro_rules! map_methods {
     };
 }
 
+macro_rules! set_methods {
+    () => {
+        fn len(&self) -> usize {
+            Self::len(self)
+        }
+
+        fn is_empty(&self) -> bool {
+            Self::is_empty(self)
+        }
+
+        fn try_insert(&mut self, element: &dyn Reflect) -> Result<bool, SetError> {
+            let element = V::from_reflect(element).ok_or(SetError)?;
+            Ok(self.insert(element))
+        }
+
+        fn try_remove(&mut self, element: &dyn Reflect) -> Result<bool, SetError> {
+            let element = V::from_reflect(element).ok_or(SetError)?;
+            Ok(self.remove(&element))
+        }
+
+        fn try_contains(&mut self, element: &dyn Reflect) -> Result<bool, SetError> {
+            let element = V::from_reflect(element).ok_or(SetError)?;
+            Ok(self.contains(&element))
+        }
+
+        fn iter(&self) -> Iter<'_> {
+            let iter = Self::iter(self).map(|element| element.as_reflect());
+            Box::new(iter)
+        }
+    };
+}
+
 /// Reflected array types.
 pub mod array;
 
@@ -364,6 +396,9 @@ pub mod list;
 
 /// Reflected map types.
 pub mod map;
+
+/// Reflected set types.
+pub mod set;
 
 /// Reflected struct types.
 pub mod struct_;
@@ -406,6 +441,8 @@ pub use self::get_field::GetFieldMut;
 pub use self::list::List;
 #[doc(inline)]
 pub use self::map::Map;
+#[doc(inline)]
+pub use self::set::Set;
 #[doc(inline)]
 pub use self::struct_::Struct;
 #[doc(inline)]
@@ -567,6 +604,18 @@ pub trait Reflect: Any + Send + 'static {
 
     fn as_map_mut(&mut self) -> Option<&mut dyn Map> {
         self.reflect_mut().as_map_mut()
+    }
+
+    fn into_set(self: Box<Self>) -> Option<Box<dyn Set>> {
+        self.reflect_owned().into_set()
+    }
+
+    fn as_set(&self) -> Option<&dyn Set> {
+        self.reflect_ref().as_set()
+    }
+
+    fn as_set_mut(&mut self) -> Option<&mut dyn Set> {
+        self.reflect_mut().as_set_mut()
     }
 
     fn into_scalar(self: Box<Self>) -> Option<ScalarOwned> {
@@ -774,6 +823,7 @@ pub enum ReflectOwned {
     Array(Box<dyn Array>),
     List(Box<dyn List>),
     Map(Box<dyn Map>),
+    Set(Box<dyn Set>),
     Scalar(ScalarOwned),
     /// Not all `Reflect` implementations allow access to the underlying value. This variant can be
     /// used for such types.
@@ -790,6 +840,7 @@ impl ReflectOwned {
             ReflectOwned::Array(inner) => inner.as_reflect_mut(),
             ReflectOwned::List(inner) => inner.as_reflect_mut(),
             ReflectOwned::Map(inner) => inner.as_reflect_mut(),
+            ReflectOwned::Set(inner) => inner.as_reflect_mut(),
             ReflectOwned::Scalar(inner) => inner.as_reflect_mut(),
             ReflectOwned::Opaque(inner) => inner.as_reflect_mut(),
         }
@@ -804,6 +855,7 @@ impl ReflectOwned {
             ReflectOwned::Array(inner) => inner.as_reflect(),
             ReflectOwned::List(inner) => inner.as_reflect(),
             ReflectOwned::Map(inner) => inner.as_reflect(),
+            ReflectOwned::Set(inner) => inner.as_reflect(),
             ReflectOwned::Scalar(inner) => inner.as_reflect(),
             ReflectOwned::Opaque(inner) => inner.as_reflect(),
         }
@@ -858,6 +910,13 @@ impl ReflectOwned {
         }
     }
 
+    pub fn into_set(self) -> Option<Box<dyn Set>> {
+        match self {
+            Self::Set(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
     pub fn into_scalar(self) -> Option<ScalarOwned> {
         match self {
             Self::Scalar(inner) => Some(inner),
@@ -883,6 +942,7 @@ impl Clone for ReflectOwned {
             Self::Array(inner) => inner.clone_reflect().reflect_owned(),
             Self::List(inner) => inner.clone_reflect().reflect_owned(),
             Self::Map(inner) => inner.clone_reflect().reflect_owned(),
+            Self::Set(inner) => inner.clone_reflect().reflect_owned(),
             Self::Opaque(inner) => inner.clone_reflect().reflect_owned(),
             Self::Scalar(inner) => Self::Scalar(inner.clone()),
         }
@@ -969,6 +1029,7 @@ pub enum ReflectRef<'a> {
     Array(&'a dyn Array),
     List(&'a dyn List),
     Map(&'a dyn Map),
+    Set(&'a dyn Set),
     Scalar(ScalarRef<'a>),
     /// Not all `Reflect` implementations allow access to the underlying value. This variant can be
     /// used for such types.
@@ -985,6 +1046,7 @@ impl<'a> ReflectRef<'a> {
             ReflectRef::Array(inner) => inner.as_reflect(),
             ReflectRef::List(inner) => inner.as_reflect(),
             ReflectRef::Map(inner) => inner.as_reflect(),
+            ReflectRef::Set(inner) => inner.as_reflect(),
             ReflectRef::Scalar(inner) => inner.as_reflect(),
             ReflectRef::Opaque(inner) => inner.as_reflect(),
         }
@@ -1035,6 +1097,13 @@ impl<'a> ReflectRef<'a> {
     pub fn as_map(self) -> Option<&'a dyn Map> {
         match self {
             Self::Map(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_set(self) -> Option<&'a dyn Set> {
+        match self {
+            Self::Set(inner) => Some(inner),
             _ => None,
         }
     }
@@ -1111,6 +1180,7 @@ pub enum ReflectMut<'a> {
     Array(&'a mut dyn Array),
     List(&'a mut dyn List),
     Map(&'a mut dyn Map),
+    Set(&'a mut dyn Set),
     Scalar(ScalarMut<'a>),
     /// Not all `Reflect` implementations allow mutable access to the underlying value (such as
     /// [`core::num::NonZeroU8`]). This variant can be used for such types.
@@ -1127,6 +1197,7 @@ impl<'a> ReflectMut<'a> {
             ReflectMut::Array(inner) => inner.as_reflect_mut(),
             ReflectMut::List(inner) => inner.as_reflect_mut(),
             ReflectMut::Map(inner) => inner.as_reflect_mut(),
+            ReflectMut::Set(inner) => inner.as_reflect_mut(),
             ReflectMut::Scalar(inner) => inner.as_reflect_mut(),
             ReflectMut::Opaque(inner) => inner.as_reflect_mut(),
         }
@@ -1141,6 +1212,7 @@ impl<'a> ReflectMut<'a> {
             ReflectMut::Array(inner) => inner.as_reflect(),
             ReflectMut::List(inner) => inner.as_reflect(),
             ReflectMut::Map(inner) => inner.as_reflect(),
+            ReflectMut::Set(inner) => inner.as_reflect(),
             ReflectMut::Scalar(inner) => inner.as_reflect(),
             ReflectMut::Opaque(inner) => inner.as_reflect(),
         }
@@ -1191,6 +1263,13 @@ impl<'a> ReflectMut<'a> {
     pub fn as_map_mut(self) -> Option<&'a mut dyn Map> {
         match self {
             Self::Map(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_set_mut(self) -> Option<&'a mut dyn Set> {
+        match self {
+            Self::Set(inner) => Some(inner),
             _ => None,
         }
     }
@@ -1345,6 +1424,7 @@ pub fn reflect_debug(value: &dyn Reflect, f: &mut core::fmt::Formatter<'_>) -> c
         ReflectRef::Array(inner) => f.debug_list().entries(inner.iter()).finish(),
         ReflectRef::List(inner) => f.debug_list().entries(inner.iter()).finish(),
         ReflectRef::Map(inner) => f.debug_map().entries(inner.iter()).finish(),
+        ReflectRef::Set(inner) => f.debug_set().entries(inner.iter()).finish(),
         ReflectRef::Scalar(inner) => match inner {
             ScalarRef::usize(inner) => scalar_debug(&inner, f),
             ScalarRef::u8(inner) => scalar_debug(&inner, f),

--- a/crates/mirror-mirror/src/reflect_eq.rs
+++ b/crates/mirror-mirror/src/reflect_eq.rs
@@ -1,6 +1,6 @@
 use crate::{
     enum_::{VariantField, VariantKind},
-    Array, Enum, List, Map, Reflect, ReflectRef, Struct, Tuple, TupleStruct,
+    Array, Enum, List, Map, Reflect, ReflectRef, Set, Struct, Tuple, TupleStruct,
 };
 
 /// Compare two reflected values for equality.
@@ -15,6 +15,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
         (ReflectRef::Enum(a), ReflectRef::Enum(b)) => reflect_eq_enum(a, b),
         (ReflectRef::Array(a), ReflectRef::Array(b)) => reflect_eq_array(a, b),
         (ReflectRef::List(a), ReflectRef::List(b)) => reflect_eq_list(a, b),
+        (ReflectRef::Set(a), ReflectRef::Set(b)) => reflect_eq_set(a, b),
         (ReflectRef::Map(a), ReflectRef::Map(b)) => reflect_eq_map(a, b),
         (ReflectRef::Opaque(_), _) | (_, ReflectRef::Opaque(_)) => None,
 
@@ -25,6 +26,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Array(_)
             | ReflectRef::List(_)
             | ReflectRef::Map(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::TupleStruct(_),
         )
@@ -35,6 +37,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Array(_)
             | ReflectRef::List(_)
             | ReflectRef::Map(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::Tuple(_),
         )
@@ -45,6 +48,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Array(_)
             | ReflectRef::List(_)
             | ReflectRef::Map(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::Enum(_),
         )
@@ -55,6 +59,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Enum(_)
             | ReflectRef::List(_)
             | ReflectRef::Map(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::Array(_),
         )
@@ -65,6 +70,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Enum(_)
             | ReflectRef::Array(_)
             | ReflectRef::Map(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::List(_),
         )
@@ -74,7 +80,19 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Tuple(_)
             | ReflectRef::Enum(_)
             | ReflectRef::Array(_)
+            | ReflectRef::Map(_)
             | ReflectRef::List(_)
+            | ReflectRef::Scalar(_),
+            ReflectRef::Set(_),
+        )
+        | (
+            ReflectRef::Struct(_)
+            | ReflectRef::TupleStruct(_)
+            | ReflectRef::Tuple(_)
+            | ReflectRef::Enum(_)
+            | ReflectRef::Array(_)
+            | ReflectRef::List(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::Map(_),
         )
@@ -85,6 +103,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Enum(_)
             | ReflectRef::Array(_)
             | ReflectRef::List(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Map(_),
             ReflectRef::Scalar(_),
         )
@@ -95,6 +114,7 @@ pub fn reflect_eq(a: &dyn Reflect, b: &dyn Reflect) -> Option<bool> {
             | ReflectRef::Array(_)
             | ReflectRef::List(_)
             | ReflectRef::Map(_)
+            | ReflectRef::Set(_)
             | ReflectRef::Scalar(_),
             ReflectRef::Struct(_),
         ) => Some(false),
@@ -236,6 +256,23 @@ fn reflect_eq_array(a: &dyn Array, b: &dyn Array) -> Option<bool> {
 }
 
 fn reflect_eq_list(a: &dyn List, b: &dyn List) -> Option<bool> {
+    Some(
+        a.len() == b.len() && {
+            for (value_a, value_b) in a.iter().zip(b.iter()) {
+                match reflect_eq(value_a, value_b) {
+                    Some(true) => {}
+                    Some(false) => {
+                        return Some(false);
+                    }
+                    None => return None,
+                }
+            }
+            true
+        },
+    )
+}
+
+fn reflect_eq_set(a: &dyn Set, b: &dyn Set) -> Option<bool> {
     Some(
         a.len() == b.len() && {
             for (value_a, value_b) in a.iter().zip(b.iter()) {

--- a/crates/mirror-mirror/src/set.rs
+++ b/crates/mirror-mirror/src/set.rs
@@ -1,0 +1,38 @@
+use crate::Reflect;
+
+use core::fmt;
+
+pub trait Set: Reflect {
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool;
+
+    fn try_insert(&mut self, element: &dyn Reflect) -> Result<bool, SetError>;
+
+    fn try_remove(&mut self, element: &dyn Reflect) -> Result<bool, SetError>;
+
+    fn try_contains(&mut self, element: &dyn Reflect) -> Result<bool, SetError>;
+
+    fn iter(&self) -> Iter<'_>;
+}
+
+impl fmt::Debug for dyn Set {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_reflect().debug(f)
+    }
+}
+
+pub type Iter<'a> = Box<dyn Iterator<Item = &'a dyn Reflect> + 'a>;
+
+/// A method on a reflected set failed.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct SetError;
+
+impl core::fmt::Display for SetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to parse element")
+    }
+}
+
+impl std::error::Error for SetError {}

--- a/crates/mirror-mirror/src/try_visit.rs
+++ b/crates/mirror-mirror/src/try_visit.rs
@@ -135,6 +135,14 @@ where
                 try_visit(visitor, value, value_ty)?;
             }
         }
+        Type::Set(set_ty) => {
+            let set = value.as_set().unwrap();
+            let element_ty = set_ty.element_type();
+
+            for element in set.iter() {
+                try_visit(visitor, element, element_ty)?;
+            }
+        }
         Type::Opaque(opaque_ty) => {
             visitor.try_visit_opaque(value, opaque_ty)?;
         }

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -115,6 +115,7 @@ pub enum TypeNode {
     List(ListNode),
     Array(ArrayNode),
     Map(MapNode),
+    Set(SetNode),
     Scalar(ScalarNode),
     Opaque(OpaqueNode),
 }
@@ -136,6 +137,7 @@ impl_from! { Enum(EnumNode) }
 impl_from! { List(ListNode) }
 impl_from! { Array(ArrayNode) }
 impl_from! { Map(MapNode) }
+impl_from! { Set(SetNode) }
 impl_from! { Scalar(ScalarNode) }
 impl_from! { Opaque(OpaqueNode) }
 
@@ -477,6 +479,27 @@ impl MapNode {
             type_name: type_name::<M>().to_owned(),
             key_type_id: K::build(graph),
             value_type_id: V::build(graph),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SetNode {
+    pub(super) type_name: String,
+    pub(super) element_type_id: NodeId,
+}
+
+impl SetNode {
+    pub(crate) fn new<M, V>(graph: &mut TypeGraph) -> Self
+    where
+        M: DescribeType,
+        V: DescribeType,
+    {
+        Self {
+            type_name: type_name::<M>().to_owned(),
+            element_type_id: V::build(graph),
         }
     }
 }

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -43,6 +43,7 @@ impl<'a> PrettyPrintRoot for Type<'a> {
             Type::List(inner) => inner.pretty_root_fmt(f),
             Type::Array(inner) => inner.pretty_root_fmt(f),
             Type::Map(inner) => inner.pretty_root_fmt(f),
+            Type::Set(inner) => inner.pretty_root_fmt(f),
             Type::Scalar(inner) => inner.pretty_root_fmt(f),
             Type::Opaque(inner) => inner.pretty_root_fmt(f),
         }
@@ -199,6 +200,15 @@ impl<'a> PrettyPrintRoot for MapType<'a> {
         f.write_str(": ")?;
         simple_type_name_fmt(self.value_type().type_name(), f)?;
         f.write_char(']')?;
+        Ok(())
+    }
+}
+
+impl<'a> PrettyPrintRoot for SetType<'a> {
+    fn pretty_root_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_char('{')?;
+        simple_type_name_fmt(self.element_type().type_name(), f)?;
+        f.write_char('}')?;
         Ok(())
     }
 }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -7,7 +7,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::hash::Hash;
 use core::hash::Hasher;
-use kollect::UnorderedSet;
+use kollect::OrderedSet;
 
 use kollect::LinearMap;
 use ordered_float::OrderedFloat;
@@ -58,7 +58,7 @@ pub enum Value {
     TupleStructValue(TupleStructValue),
     TupleValue(TupleValue),
     List(Vec<Value>),
-    Set(UnorderedSet<Value>),
+    Set(OrderedSet<Value>),
     Map(LinearMap<Value, Value>),
 }
 
@@ -92,7 +92,7 @@ enum OrdEqHashValue<'a> {
     TupleStructValue(&'a TupleStructValue),
     TupleValue(&'a TupleValue),
     List(&'a [Value]),
-    Set(&'a UnorderedSet<Value>),
+    Set(&'a OrderedSet<Value>),
     Map(&'a LinearMap<Value, Value>),
 }
 

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -7,7 +7,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::hash::Hash;
 use core::hash::Hasher;
-use kollect::OrderedSet;
+use kollect::LinearSet;
 
 use kollect::LinearMap;
 use ordered_float::OrderedFloat;
@@ -58,7 +58,7 @@ pub enum Value {
     TupleStructValue(TupleStructValue),
     TupleValue(TupleValue),
     List(Vec<Value>),
-    Set(OrderedSet<Value>),
+    Set(LinearSet<Value>),
     Map(LinearMap<Value, Value>),
 }
 
@@ -92,7 +92,7 @@ enum OrdEqHashValue<'a> {
     TupleStructValue(&'a TupleStructValue),
     TupleValue(&'a TupleValue),
     List(&'a [Value]),
-    Set(&'a OrderedSet<Value>),
+    Set(&'a LinearSet<Value>),
     Map(&'a LinearMap<Value, Value>),
 }
 

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -7,6 +7,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::hash::Hash;
 use core::hash::Hasher;
+use kollect::UnorderedSet;
 
 use kollect::LinearMap;
 use ordered_float::OrderedFloat;
@@ -57,6 +58,7 @@ pub enum Value {
     TupleStructValue(TupleStructValue),
     TupleValue(TupleValue),
     List(Vec<Value>),
+    Set(UnorderedSet<Value>),
     Map(LinearMap<Value, Value>),
 }
 
@@ -90,6 +92,7 @@ enum OrdEqHashValue<'a> {
     TupleStructValue(&'a TupleStructValue),
     TupleValue(&'a TupleValue),
     List(&'a [Value]),
+    Set(&'a UnorderedSet<Value>),
     Map(&'a LinearMap<Value, Value>),
 }
 
@@ -117,6 +120,7 @@ impl<'a> From<&'a Value> for OrdEqHashValue<'a> {
             Value::TupleStructValue(inner) => OrdEqHashValue::TupleStructValue(inner),
             Value::TupleValue(inner) => OrdEqHashValue::TupleValue(inner),
             Value::List(inner) => OrdEqHashValue::List(inner),
+            Value::Set(inner) => OrdEqHashValue::Set(inner),
             Value::Map(inner) => OrdEqHashValue::Map(inner),
         }
     }
@@ -175,6 +179,7 @@ macro_rules! for_each_variant {
             Value::EnumValue($inner) => $expr,
             Value::TupleValue($inner) => $expr,
             Value::List($inner) => $expr,
+            Value::Set($inner) => $expr,
             Value::Map($inner) => $expr,
         }
     };
@@ -228,6 +233,7 @@ impl Reflect for Value {
             Value::TupleStructValue(inner) => ReflectOwned::TupleStruct(Box::new(inner)),
             Value::TupleValue(inner) => ReflectOwned::Tuple(Box::new(inner)),
             Value::List(inner) => ReflectOwned::List(Box::new(inner)),
+            Value::Set(inner) => ReflectOwned::Set(Box::new(inner)),
             Value::Map(inner) => ReflectOwned::Map(Box::new(inner)),
         }
     }
@@ -255,6 +261,7 @@ impl Reflect for Value {
             Value::TupleStructValue(inner) => ReflectRef::TupleStruct(inner),
             Value::TupleValue(inner) => ReflectRef::Tuple(inner),
             Value::List(inner) => ReflectRef::List(inner),
+            Value::Set(inner) => ReflectRef::Set(inner),
             Value::Map(inner) => ReflectRef::Map(inner),
         }
     }
@@ -282,6 +289,7 @@ impl Reflect for Value {
             Value::TupleStructValue(inner) => ReflectMut::TupleStruct(inner),
             Value::TupleValue(inner) => ReflectMut::Tuple(inner),
             Value::List(inner) => ReflectMut::List(inner),
+            Value::Set(inner) => ReflectMut::Set(inner),
             Value::Map(inner) => ReflectMut::Map(inner),
         }
     }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

While working on enabling reflection for more of our internal types I ran into a bunch of `UnorderedPrimitiveSet<EntityId>`. That type doesn't implement `Reflect` because we don't support sets. I don't remember why we haven't had sets previously but I think it makes sense to have.