### PR TITLE
Remove num-traits and ordered-float

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,10 +72,10 @@ dependencies = [
  "macaw",
  "mirror-mirror-macros",
  "once_cell",
- "ordered-float",
  "serde",
  "speedy",
  "syn",
+ "tiny-ordered-float",
 ]
 
 [[package]]
@@ -106,15 +106,6 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 dependencies = [
  "critical-section",
  "portable-atomic",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -192,6 +183,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tiny-ordered-float"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a0b45a69bc9fdc3c4c2bada65d58cc5f763cee91543173a14eb4edfbdf1f62"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-ordered-float"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a0b45a69bc9fdc3c4c2bada65d58cc5f763cee91543173a14eb4edfbdf1f62"
+checksum = "3a43fe20b81bb52ecac2d82b661775b44608cdf3ea717603d69280091f126575"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -23,7 +23,7 @@ macaw = ["dep:macaw"]
 ahash = { version = "0.8.2", default-features = false }
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
-ordered-float = { version = "4", default-features = false }
+tiny-ordered-float = { version = "0.3", default-features = false }
 serde = { version = "1.0.158", default-features = false, features = ["derive", "alloc"], optional = true }
 speedy = { version = "0.8.5", optional = true }
 syn = { version = "2.0", features = ["full", "parsing"], optional = true }

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -23,7 +23,7 @@ macaw = ["dep:macaw"]
 ahash = { version = "0.8.2", default-features = false }
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
-tiny-ordered-float = { version = "0.3", default-features = false }
+tiny-ordered-float = { version = "0.4", default-features = false }
 serde = { version = "1.0.158", default-features = false, features = ["derive", "alloc"], optional = true }
 speedy = { version = "0.8.5", optional = true }
 syn = { version = "2.0", features = ["full", "parsing"], optional = true }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -9,7 +9,7 @@ use core::fmt;
 use core::hash::Hash;
 use core::hash::Hasher;
 
-use ordered_float::OrderedFloat;
+use tiny_ordered_float::{OrderedF32, OrderedF64};
 
 use crate::enum_::EnumValue;
 use crate::struct_::StructValue;
@@ -83,8 +83,8 @@ enum OrdEqHashValue<'a> {
     i128(i128),
     bool(bool),
     char(char),
-    f32(OrderedFloat<f32>),
-    f64(OrderedFloat<f64>),
+    f32(OrderedF32),
+    f64(OrderedF64),
     String(&'a str),
     StructValue(&'a StructValue),
     EnumValue(&'a EnumValue),
@@ -110,8 +110,8 @@ impl<'a> From<&'a Value> for OrdEqHashValue<'a> {
             Value::i128(inner) => OrdEqHashValue::i128(*inner),
             Value::bool(inner) => OrdEqHashValue::bool(*inner),
             Value::char(inner) => OrdEqHashValue::char(*inner),
-            Value::f32(inner) => OrdEqHashValue::f32(OrderedFloat(*inner)),
-            Value::f64(inner) => OrdEqHashValue::f64(OrderedFloat(*inner)),
+            Value::f32(inner) => OrdEqHashValue::f32(OrderedF32(*inner)),
+            Value::f64(inner) => OrdEqHashValue::f64(OrderedF64(*inner)),
             Value::String(inner) => OrdEqHashValue::String(inner),
             Value::StructValue(inner) => OrdEqHashValue::StructValue(inner),
             Value::EnumValue(inner) => OrdEqHashValue::EnumValue(inner),


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This removes `ordered-float` as a dependency and replaces it with `tiny-ordered-float` which supports just enough use-cases for this library.

This is mostly done to remove the (very slow to compile) transitive dependency `num-traits` for this crate so we can keep it lean and mean.

Notice that this doesn't remove `num-traits` from the `Cargo.lock` because the optional `macaw` dependency still wants it, but we don't use that feature so I'll leave removing `num-traits` there as an exercise for the reader.