### PR TITLE
Update `kollect` to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,17 @@ dependencies = [
  "ahash",
  "indexmap",
  "rustc-hash",
+]
+
+[[package]]
+name = "kollect"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753942edbae76822719fb0cb9c88cd1afe04ddc7fb9575d478f98cb0d9d615c5"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "rustc-hash",
  "serde",
  "speedy",
 ]
@@ -120,7 +131,7 @@ version = "0.1.19"
 dependencies = [
  "ahash",
  "glam",
- "kollect",
+ "kollect 0.4.0",
  "macaw",
  "mirror-mirror 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirror-mirror-macros 0.1.4",
@@ -151,7 +162,7 @@ dependencies = [
 name = "mirror-mirror-macros"
 version = "0.1.4"
 dependencies = [
- "kollect",
+ "kollect 0.3.2",
  "mirror-mirror 0.1.19",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,24 +117,6 @@ dependencies = [
 [[package]]
 name = "mirror-mirror"
 version = "0.1.19"
-dependencies = [
- "ahash",
- "glam",
- "kollect",
- "macaw",
- "mirror-mirror 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirror-mirror-macros 0.1.4",
- "once_cell",
- "ordered-float",
- "ron",
- "serde",
- "speedy",
- "syn",
-]
-
-[[package]]
-name = "mirror-mirror"
-version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b14e8dc2bf56db79766cf6438a1bfb33047af85a439809550101dabcd1c0c42b"
 dependencies = [
@@ -148,11 +130,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirror-mirror"
+version = "0.2.0"
+dependencies = [
+ "ahash",
+ "glam",
+ "kollect",
+ "macaw",
+ "mirror-mirror 0.1.19",
+ "mirror-mirror-macros 0.1.4",
+ "once_cell",
+ "ordered-float",
+ "ron",
+ "serde",
+ "speedy",
+ "syn",
+]
+
+[[package]]
 name = "mirror-mirror-macros"
 version = "0.1.4"
 dependencies = [
  "kollect",
- "mirror-mirror 0.1.19",
+ "mirror-mirror 0.2.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,20 +78,9 @@ dependencies = [
 
 [[package]]
 name = "kollect"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149a6226dcaffb051e49418fd3b7e2e19814688c4cabfeddbe64b0dd0767e489"
-dependencies = [
- "ahash",
- "indexmap",
- "rustc-hash",
-]
-
-[[package]]
-name = "kollect"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753942edbae76822719fb0cb9c88cd1afe04ddc7fb9575d478f98cb0d9d615c5"
+checksum = "20754ec4f34eff91fc687acca52912fb9b106c8c0325a17e7adec308a69f937f"
 dependencies = [
  "ahash",
  "indexmap",
@@ -131,7 +120,7 @@ version = "0.1.19"
 dependencies = [
  "ahash",
  "glam",
- "kollect 0.4.0",
+ "kollect",
  "macaw",
  "mirror-mirror 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirror-mirror-macros 0.1.4",
@@ -162,7 +151,7 @@ dependencies = [
 name = "mirror-mirror-macros"
 version = "0.1.4"
 dependencies = [
- "kollect 0.3.2",
+ "kollect",
  "mirror-mirror 0.1.19",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b14e8dc2bf56db79766cf6438a1bfb33047af85a439809550101dabcd1c0c42b"
 dependencies = [
  "ahash",
- "mirror-mirror-macros 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirror-mirror-macros 0.1.4",
  "once_cell",
  "ordered-float",
  "serde",
@@ -138,7 +138,7 @@ dependencies = [
  "kollect",
  "macaw",
  "mirror-mirror 0.1.19",
- "mirror-mirror-macros 0.1.4",
+ "mirror-mirror-macros 0.2.0",
  "once_cell",
  "ordered-float",
  "ron",
@@ -150,9 +150,9 @@ dependencies = [
 [[package]]
 name = "mirror-mirror-macros"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873a8136d73249ded007bc60b4a2e0fc44558469e622f86a84e906361fb79131"
 dependencies = [
- "kollect",
- "mirror-mirror 0.2.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -160,10 +160,10 @@ dependencies = [
 
 [[package]]
 name = "mirror-mirror-macros"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873a8136d73249ded007bc60b4a2e0fc44558469e622f86a84e906361fb79131"
+version = "0.2.0"
 dependencies = [
+ "kollect",
+ "mirror-mirror 0.2.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/crates/mirror-mirror-macros/Cargo.toml
+++ b/crates/mirror-mirror-macros/Cargo.toml
@@ -19,7 +19,7 @@ quote = "1.0.21"
 syn = { version = "2.0.2", features = ["full", "parsing", "visit"] }
 
 [dev-dependencies]
-mirror-mirror = { path = "../mirror-mirror", version = "0.1", default-features = false }
+mirror-mirror = { path = "../mirror-mirror", version = "0.2", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mirror-mirror-macros/Cargo.toml
+++ b/crates/mirror-mirror-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-mirror-macros"
-version = "0.1.4" # remember to bump the version `mirror-mirror` depends on
+version = "0.2.0" # remember to bump the version `mirror-mirror` depends on
 edition = "2021"
 authors = ["Embark <opensource@embark-studios.com>", "David Pedersen <david.pdrsn@gmail.com>"]
 repository = "https://github.com/EmbarkStudios/mirror-mirror"

--- a/crates/mirror-mirror-macros/Cargo.toml
+++ b/crates/mirror-mirror-macros/Cargo.toml
@@ -13,7 +13,7 @@ description = "Macros for the mirror-mirror crate"
 proc-macro = true
 
 [dependencies]
-kollect = { version = "0.3.2", default-features = false }
+kollect = { version = "0.4.1", default-features = false }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
 syn = { version = "2.0.2", features = ["full", "parsing", "visit"] }

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -24,7 +24,7 @@ ahash = { version = "0.8.2", default-features = false, features = [
     # required for wasm support
     "no-rng",
 ] }
-kollect = { version = "0.3.2", default-features = false }
+kollect = { version = "0.4.0", default-features = false }
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
 ordered-float = { version = "4", default-features = false }

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -25,7 +25,7 @@ ahash = { version = "0.8.2", default-features = false, features = [
     "no-rng",
 ] }
 kollect = { version = "0.4.1", default-features = false }
-mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
+mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.2.0" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
 ordered-float = { version = "4", default-features = false }
 serde = { version = "1.0.158", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -24,7 +24,7 @@ ahash = { version = "0.8.2", default-features = false, features = [
     # required for wasm support
     "no-rng",
 ] }
-kollect = { version = "0.4.0", default-features = false }
+kollect = { version = "0.4.1", default-features = false }
 mirror-mirror-macros = { path = "../mirror-mirror-macros", version = "0.1.4" }
 once_cell = { version = "1.16", features = ["alloc", "race", "critical-section"], default-features = false }
 ordered-float = { version = "4", default-features = false }

--- a/crates/mirror-mirror/Cargo.toml
+++ b/crates/mirror-mirror/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-mirror"
-version = "0.1.19"
+version = "0.2.0"
 edition = "2021"
 authors = ["Embark <opensource@embark-studios.com>", "David Pedersen <david.pdrsn@gmail.com>"]
 repository = "https://github.com/EmbarkStudios/mirror-mirror"

--- a/crates/mirror-mirror/src/struct_.rs
+++ b/crates/mirror-mirror/src/struct_.rs
@@ -51,6 +51,7 @@ impl fmt::Debug for dyn Struct {
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StructValue {
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     fields: LinearMap<String, Value>,
 }
 

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -59,6 +59,7 @@ impl<T> Deref for WithId<T> {
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TypeGraph {
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) map: LinearMap<NodeId, Option<TypeNode>>,
 }
 
@@ -146,7 +147,9 @@ impl_from! { Opaque(OpaqueNode) }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StructNode {
     pub(super) type_name: String,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) fields: LinearMap<String, NamedFieldNode>,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
     pub(super) default_value: Option<Value>,
@@ -191,6 +194,7 @@ fn map_docs(docs: &[&'static str]) -> Box<[String]> {
 pub struct TupleStructNode {
     pub(super) type_name: String,
     pub(super) fields: Vec<UnnamedFieldNode>,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
     pub(super) default_value: Option<Value>,
@@ -221,6 +225,7 @@ impl TupleStructNode {
 pub struct EnumNode {
     pub(super) type_name: String,
     pub(super) variants: Vec<VariantNode>,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
     pub(super) default_value: Option<Value>,
@@ -259,7 +264,9 @@ pub enum VariantNode {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StructVariantNode {
     pub(super) name: String,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) fields: LinearMap<String, NamedFieldNode>,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
 }
@@ -289,6 +296,7 @@ impl StructVariantNode {
 pub struct TupleVariantNode {
     pub(super) name: String,
     pub(super) fields: Vec<UnnamedFieldNode>,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
 }
@@ -314,6 +322,7 @@ impl TupleVariantNode {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnitVariantNode {
     pub(super) name: String,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
 }
@@ -338,6 +347,7 @@ impl UnitVariantNode {
 pub struct TupleNode {
     pub(super) type_name: String,
     pub(super) fields: Vec<UnnamedFieldNode>,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
 }
@@ -366,6 +376,7 @@ impl TupleNode {
 pub struct NamedFieldNode {
     pub(super) name: String,
     pub(super) id: NodeId,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
 }
@@ -394,6 +405,7 @@ impl NamedFieldNode {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnnamedFieldNode {
     pub(super) id: NodeId,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) docs: Box<[String]>,
 }
@@ -551,6 +563,7 @@ scalar_typed! {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpaqueNode {
     pub(super) type_name: String,
+    #[cfg_attr(feature = "serde", serde(with = "kollect::linear_map::serde_as_map"))]
     pub(super) metadata: LinearMap<String, Value>,
     pub(super) default_value: Option<Value>,
 }


### PR DESCRIPTION
This bumps `kollect` to 0.4.0, which I've just released, the only change being changing the default serialization format of maps to be as sequences of `(k, v)` pairs. Thus this is a breaking serialization change. We should therefore not bump this version into wim until the PR that intentionally breaks a bunch of data which this is being used for.