### PR TITLE
Fix name collisions

### DIFF
--- a/crates/mirror-mirror-macros/src/lib.rs
+++ b/crates/mirror-mirror-macros/src/lib.rs
@@ -11,7 +11,6 @@
     clippy::needless_borrow,
     clippy::match_wildcard_for_single_variants,
     clippy::if_let_mutex,
-    clippy::mismatched_target_os,
     clippy::await_holding_lock,
     clippy::match_on_vec_items,
     clippy::imprecise_flops,

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -222,7 +222,6 @@
     clippy::needless_borrow,
     clippy::match_wildcard_for_single_variants,
     clippy::if_let_mutex,
-    clippy::mismatched_target_os,
     clippy::await_holding_lock,
     clippy::match_on_vec_items,
     clippy::imprecise_flops,

--- a/crates/mirror-mirror/src/tests/enum_.rs
+++ b/crates/mirror-mirror/src/tests/enum_.rs
@@ -505,3 +505,46 @@ fn default_value_for_enum_variant_type() {
         Foo::C { a: 0.0, b: None },
     );
 }
+
+#[test]
+fn field_named_named() {
+    #[derive(Reflect, Debug, Clone)]
+    #[reflect(crate_name(crate), opt_out(Default))]
+    enum A {
+        Struct {
+            name: String,
+        },
+        // some other field names that shouldn't collide with generated code
+        Struct2 {
+            value: (),
+            reflect: (),
+            enum_: (),
+            struct_: (),
+        },
+    }
+
+    let mut a = A::Struct {
+        name: "foo".to_owned(),
+    };
+
+    assert_eq!(
+        a.as_reflect()
+            .as_enum()
+            .unwrap()
+            .field("name")
+            .unwrap()
+            .downcast_ref::<String>()
+            .unwrap(),
+        "foo"
+    );
+    assert_eq!(
+        a.as_reflect_mut()
+            .as_enum_mut()
+            .unwrap()
+            .field_mut("name")
+            .unwrap()
+            .downcast_mut::<String>()
+            .unwrap(),
+        "foo"
+    );
+}

--- a/crates/mirror-mirror/src/tests/struct_.rs
+++ b/crates/mirror-mirror/src/tests/struct_.rs
@@ -410,3 +410,45 @@ fn default_value() {
     assert_eq!(foo_descriptor.default_value(), Some(foo_default));
     assert_eq!(bar_descriptor.default_value(), None);
 }
+
+#[test]
+fn field_named_named() {
+    #[derive(Reflect, Debug, Clone)]
+    #[reflect(crate_name(crate), opt_out(Default))]
+    struct A {
+        name: String,
+        value: (),
+        reflect: (),
+        enum_: (),
+        struct_: (),
+    }
+
+    let mut a = A {
+        name: "foo".to_owned(),
+        value: (),
+        reflect: (),
+        enum_: (),
+        struct_: (),
+    };
+
+    assert_eq!(
+        a.as_reflect()
+            .as_struct()
+            .unwrap()
+            .field("name")
+            .unwrap()
+            .downcast_ref::<String>()
+            .unwrap(),
+        "foo"
+    );
+    assert_eq!(
+        a.as_reflect_mut()
+            .as_struct_mut()
+            .unwrap()
+            .field_mut("name")
+            .unwrap()
+            .downcast_mut::<String>()
+            .unwrap(),
+        "foo"
+    );
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

If you had an enum variant with a field called `name` then methods like `field` and `field_mut` wouldn't work due to variable name collisions in the generated code. This fixes that by prefixing generated variable names with `__mirror_mirror`.
