### PR TITLE
Attempting to add `core::net::{IpAddr,Ipv4Addr,Ipv6Addr}`

### DIFF
--- a/crates/mirror-mirror/src/foreign_impls/mod.rs
+++ b/crates/mirror-mirror/src/foreign_impls/mod.rs
@@ -1,4 +1,5 @@
 use core::convert::Infallible;
+use core::net::{IpAddr};
 use core::ops::Range;
 use core::ops::RangeFrom;
 use core::ops::RangeFull;
@@ -88,6 +89,15 @@ __private_derive_reflect_foreign! {
         Idx: FromReflect + DescribeType,
     {
         end: Idx,
+    }
+}
+
+__private_derive_reflect_foreign! {
+    #[reflect(opt_out(Clone, Debug, Default), crate_name(crate))]
+    enum IpAddr
+    {
+        V4(Ipv4Addr),
+        V6(Ipv6Addr),
     }
 }
 

--- a/crates/mirror-mirror/src/key_path.rs
+++ b/crates/mirror-mirror/src/key_path.rs
@@ -591,6 +591,8 @@ pub(crate) fn value_to_usize(value: &Value) -> Option<usize> {
         | Value::f32(_)
         | Value::f64(_)
         | Value::String(_)
+        | Value::Ipv4Addr(_)
+        | Value::Ipv6Addr(_)
         | Value::StructValue(_)
         | Value::EnumValue(_)
         | Value::TupleStructValue(_)

--- a/crates/mirror-mirror/src/lib.rs
+++ b/crates/mirror-mirror/src/lib.rs
@@ -265,6 +265,7 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use core::any::Any;
 use core::fmt;
+use core::net::{Ipv4Addr,Ipv6Addr};
 
 use crate::enum_::VariantField;
 use crate::enum_::VariantKind;
@@ -748,6 +749,7 @@ impl_for_core_types! {
     i8 i16 i32 i64 i128
     f32 f64
     bool char
+    Ipv4Addr Ipv6Addr
 }
 
 impl Reflect for String {
@@ -979,6 +981,8 @@ pub enum ScalarOwned {
     f32(f32),
     f64(f64),
     String(String),
+    Ipv4Addr(Ipv4Addr),
+    Ipv6Addr(Ipv6Addr),
 }
 
 impl ScalarOwned {
@@ -1000,6 +1004,8 @@ impl ScalarOwned {
             ScalarOwned::f32(inner) => inner,
             ScalarOwned::f64(inner) => inner,
             ScalarOwned::String(inner) => inner,
+            ScalarOwned::Ipv4Addr(inner) => inner,
+            ScalarOwned::Ipv6Addr(inner) => inner,
         }
     }
 
@@ -1021,6 +1027,8 @@ impl ScalarOwned {
             ScalarOwned::f32(inner) => inner,
             ScalarOwned::f64(inner) => inner,
             ScalarOwned::String(inner) => inner,
+            ScalarOwned::Ipv4Addr(inner) => inner,
+            ScalarOwned::Ipv6Addr(inner) => inner,
         }
     }
 }
@@ -1151,6 +1159,8 @@ pub enum ScalarRef<'a> {
     f32(f32),
     f64(f64),
     String(&'a String),
+    Ipv4Addr(Ipv4Addr),
+    Ipv6Addr(Ipv6Addr),
 }
 
 impl ScalarRef<'_> {
@@ -1172,6 +1182,8 @@ impl ScalarRef<'_> {
             ScalarRef::f32(inner) => inner,
             ScalarRef::f64(inner) => inner,
             ScalarRef::String(inner) => *inner,
+            ScalarRef::Ipv4Addr(inner) => inner,
+            ScalarRef::Ipv6Addr(inner) => inner,
         }
     }
 }
@@ -1317,6 +1329,8 @@ pub enum ScalarMut<'a> {
     f32(&'a mut f32),
     f64(&'a mut f64),
     String(&'a mut String),
+    Ipv4Addr(&'a mut Ipv4Addr),
+    Ipv6Addr(&'a mut Ipv6Addr),
 }
 
 impl ScalarMut<'_> {
@@ -1338,6 +1352,8 @@ impl ScalarMut<'_> {
             ScalarMut::f32(inner) => *inner,
             ScalarMut::f64(inner) => *inner,
             ScalarMut::String(inner) => *inner,
+            ScalarMut::Ipv4Addr(inner) => *inner,
+            ScalarMut::Ipv6Addr(inner) => *inner,
         }
     }
 
@@ -1359,6 +1375,8 @@ impl ScalarMut<'_> {
             ScalarMut::f32(inner) => *inner,
             ScalarMut::f64(inner) => *inner,
             ScalarMut::String(inner) => *inner,
+            ScalarMut::Ipv4Addr(inner) => *inner,
+            ScalarMut::Ipv6Addr(inner) => *inner,
         }
     }
 }
@@ -1450,6 +1468,8 @@ pub fn reflect_debug(value: &dyn Reflect, f: &mut core::fmt::Formatter<'_>) -> c
             ScalarRef::f32(inner) => scalar_debug(&inner, f),
             ScalarRef::f64(inner) => scalar_debug(&inner, f),
             ScalarRef::String(inner) => scalar_debug(&inner, f),
+            ScalarRef::Ipv4Addr(inner) => scalar_debug(&inner, f),
+            ScalarRef::Ipv6Addr(inner) => scalar_debug(&inner, f),
         },
         ReflectRef::Opaque(_) => {
             write!(f, "{}", value.type_name())

--- a/crates/mirror-mirror/src/tests/ipaddr.rs
+++ b/crates/mirror-mirror/src/tests/ipaddr.rs
@@ -1,0 +1,33 @@
+use core::net::IpAddr;
+
+use crate::DescribeType;
+use crate::type_info::{Variant,Type,ScalarType};
+
+#[test]
+fn ipaddress_type_info() {
+    let type_info = <IpAddr as DescribeType>::type_descriptor();
+    assert_eq!(type_info.get_type().type_name(), "core::net::ip_addr::IpAddr");
+    let enum_ = type_info.as_enum().unwrap();
+    assert_eq!(enum_.variants_len(), 2);
+
+    
+    let ipv4 = match enum_.variant("V4").unwrap() {
+        Variant::Tuple(x) => x,
+        y => panic!("incorrect variant type: '{:?}'", y),
+    };
+    assert_eq!(ipv4.fields_len(), 1);
+    let inner = match ipv4.field_type_at(0).unwrap().get_type() {
+        Type::Scalar(ScalarType::Ipv4Addr) => { },
+        y => panic!("incorrect interior type: '{:?}'", y),
+    };
+
+    let ipv6 = match enum_.variant("V6").unwrap() {
+        Variant::Tuple(x) => x,
+        y => panic!("incorrect variant type: '{:?}'", y),
+    };
+    assert_eq!(ipv6.fields_len(), 1);
+    let inner = match ipv6.field_type_at(0).unwrap().get_type() {
+        Type::Scalar(ScalarType::Ipv6Addr) => { },
+        y => panic!("incorrect interior type: '{:?}'", y),
+    };
+}

--- a/crates/mirror-mirror/src/tests/mod.rs
+++ b/crates/mirror-mirror/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod array;
 mod enum_;
 mod key_path;
 mod list;
+mod ipaddr;
 mod map;
 mod meta;
 mod simple_type_name;

--- a/crates/mirror-mirror/src/try_visit.rs
+++ b/crates/mirror-mirror/src/try_visit.rs
@@ -3,6 +3,7 @@ use crate::{
     Reflect, ScalarRef,
 };
 use alloc::string::String;
+use core::net::{Ipv4Addr,Ipv6Addr};
 
 macro_rules! visit_scalar_fn {
     ($name:ident, $ty:ty) => {
@@ -34,6 +35,8 @@ pub trait TryVisit {
     visit_scalar_fn!(try_visit_f32, f32);
     visit_scalar_fn!(try_visit_f64, f64);
     visit_scalar_fn!(try_visit_string, &String);
+    visit_scalar_fn!(try_visit_ipv4, Ipv4Addr);
+    visit_scalar_fn!(try_visit_ipv6, Ipv6Addr);
 
     #[inline]
     fn try_visit_opaque(
@@ -69,6 +72,8 @@ where
                 ScalarRef::char(inner) => visitor.try_visit_char(inner)?,
                 ScalarRef::f64(inner) => visitor.try_visit_f64(inner)?,
                 ScalarRef::String(inner) => visitor.try_visit_string(inner)?,
+                ScalarRef::Ipv4Addr(inner) => visitor.try_visit_ipv4(inner)?,
+                ScalarRef::Ipv6Addr(inner) => visitor.try_visit_ipv6(inner)?,
             }
         }
         Type::Struct(struct_ty) => {

--- a/crates/mirror-mirror/src/type_info/graph.rs
+++ b/crates/mirror-mirror/src/type_info/graph.rs
@@ -6,6 +6,7 @@ use core::any::type_name;
 use core::any::TypeId;
 use core::hash::Hash;
 use core::hash::Hasher;
+use core::net::{Ipv4Addr,Ipv6Addr};
 use core::ops::Deref;
 use kollect::LinearMap;
 
@@ -537,6 +538,8 @@ pub enum ScalarNode {
     f32,
     f64,
     String,
+    Ipv4Addr,
+    Ipv6Addr,
 }
 
 macro_rules! scalar_typed {
@@ -556,6 +559,7 @@ scalar_typed! {
     i8 i16 i32 i64 i128
     f32 f64
     bool char String
+    Ipv4Addr Ipv6Addr
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/mirror-mirror/src/type_info/mod.rs
+++ b/crates/mirror-mirror/src/type_info/mod.rs
@@ -262,6 +262,8 @@ impl<'a> Type<'a> {
                     ScalarNode::f32 => ScalarType::f32,
                     ScalarNode::f64 => ScalarType::f64,
                     ScalarNode::String => ScalarType::String,
+                    ScalarNode::Ipv4Addr => ScalarType::Ipv4Addr,
+                    ScalarNode::Ipv6Addr => ScalarType::Ipv6Addr,
                 };
                 Type::Scalar(node)
             }
@@ -362,6 +364,8 @@ impl<'a> Type<'a> {
                 ScalarType::f32 => <f32 as DescribeType>::type_descriptor(),
                 ScalarType::f64 => <f64 as DescribeType>::type_descriptor(),
                 ScalarType::String => <String as DescribeType>::type_descriptor(),
+                ScalarType::Ipv4Addr => <core::net::Ipv4Addr as DescribeType>::type_descriptor(),
+                ScalarType::Ipv6Addr => <core::net::Ipv6Addr as DescribeType>::type_descriptor(),
             },
             Type::Opaque(inner) => Cow::Owned(inner.into_type_descriptor()),
         }
@@ -624,6 +628,8 @@ pub enum ScalarType {
     f32,
     f64,
     String,
+    Ipv4Addr,
+    Ipv6Addr,
 }
 
 impl ScalarType {
@@ -645,6 +651,8 @@ impl ScalarType {
             ScalarType::f32 => type_name::<f32>(),
             ScalarType::f64 => type_name::<f64>(),
             ScalarType::String => type_name::<String>(),
+            ScalarType::Ipv4Addr => type_name::<core::net::Ipv4Addr>(),
+            ScalarType::Ipv6Addr => type_name::<core::net::Ipv6Addr>(),
         }
     }
 
@@ -670,6 +678,8 @@ impl ScalarType {
             ScalarType::f32 => f32::default().to_value(),
             ScalarType::f64 => f64::default().to_value(),
             ScalarType::String => String::default().to_value(),
+            ScalarType::Ipv4Addr => core::net::Ipv4Addr::LOCALHOST.to_value(),
+            ScalarType::Ipv6Addr => core::net::Ipv6Addr::LOCALHOST.to_value(),
         }
     }
 

--- a/crates/mirror-mirror/src/type_info/pretty_print.rs
+++ b/crates/mirror-mirror/src/type_info/pretty_print.rs
@@ -232,6 +232,8 @@ impl PrettyPrintRoot for ScalarType {
             ScalarType::f32 => f.write_str("f32")?,
             ScalarType::f64 => f.write_str("f64")?,
             ScalarType::String => f.write_str("String")?,
+            ScalarType::Ipv4Addr => f.write_str("Ipv4Addr")?,
+            ScalarType::Ipv6Addr => f.write_str("Ipv6Addr")?,
         }
         Ok(())
     }

--- a/crates/mirror-mirror/src/value.rs
+++ b/crates/mirror-mirror/src/value.rs
@@ -7,6 +7,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::hash::Hash;
 use core::hash::Hasher;
+use core::net::{Ipv4Addr,Ipv6Addr};
 use kollect::LinearSet;
 
 use kollect::LinearMap;
@@ -61,6 +62,8 @@ pub enum Value {
     List(Vec<Value>),
     Set(LinearSet<Value>),
     Map(LinearMap<Value, Value>),
+    Ipv4Addr(Ipv4Addr),
+    Ipv6Addr(Ipv6Addr),
 }
 
 impl FromReflect for Value {
@@ -95,6 +98,8 @@ enum OrdEqHashValue<'a> {
     List(&'a [Value]),
     Set(&'a LinearSet<Value>),
     Map(&'a LinearMap<Value, Value>),
+    Ipv4Addr(Ipv4Addr),
+    Ipv6Addr(Ipv6Addr),
 }
 
 impl<'a> From<&'a Value> for OrdEqHashValue<'a> {
@@ -123,6 +128,8 @@ impl<'a> From<&'a Value> for OrdEqHashValue<'a> {
             Value::List(inner) => OrdEqHashValue::List(inner),
             Value::Set(inner) => OrdEqHashValue::Set(inner),
             Value::Map(inner) => OrdEqHashValue::Map(inner),
+            Value::Ipv4Addr(inner) => OrdEqHashValue::Ipv4Addr(*inner),
+            Value::Ipv6Addr(inner) => OrdEqHashValue::Ipv6Addr(*inner),
         }
     }
 }
@@ -182,6 +189,8 @@ macro_rules! for_each_variant {
             Value::List($inner) => $expr,
             Value::Set($inner) => $expr,
             Value::Map($inner) => $expr,
+            Value::Ipv4Addr($inner) => $expr,
+            Value::Ipv6Addr($inner) => $expr,
         }
     };
 }
@@ -261,6 +270,8 @@ impl Reflect for Value {
             Value::List(inner) => ReflectOwned::List(Box::new(inner)),
             Value::Set(inner) => ReflectOwned::Set(Box::new(inner)),
             Value::Map(inner) => ReflectOwned::Map(Box::new(inner)),
+            Value::Ipv4Addr(_) => todo!(),
+            Value::Ipv6Addr(_) => todo!(),
         }
     }
 
@@ -289,6 +300,8 @@ impl Reflect for Value {
             Value::List(inner) => ReflectRef::List(inner),
             Value::Set(inner) => ReflectRef::Set(inner),
             Value::Map(inner) => ReflectRef::Map(inner),
+            Value::Ipv4Addr(_) => todo!(),
+            Value::Ipv6Addr(_) => todo!(),
         }
     }
 
@@ -317,6 +330,8 @@ impl Reflect for Value {
             Value::List(inner) => ReflectMut::List(inner),
             Value::Set(inner) => ReflectMut::Set(inner),
             Value::Map(inner) => ReflectMut::Map(inner),
+            Value::Ipv4Addr(_) => todo!(),
+            Value::Ipv6Addr(_) => todo!(),
         }
     }
 
@@ -385,4 +400,5 @@ from_impls! {
     f32 f64
     bool char String
     TupleValue TupleStructValue
+    Ipv4Addr Ipv6Addr
 }


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Attempt to add compatibility with `Reflect` & `DescribeType` to standard library's `core::net::{IpAddr, Ipv4Addr, Ipv6Addr}` .

So

1. Add `core::net::Ipv4Addr` to `Scalar`, `ScalarRef`, `ScalarMut`, and `ScalarOwned`
3. Add `core::net::Ipv6Addr` to `Scalar`, etc. etc.
4. Implement `DescribeType`, `Enum`, and `Reflect` on `core::net::IpAddr`
5. Add some tests.

### Related Issues

I had opened -> https://github.com/EmbarkStudios/mirror-mirror/issues/156

### Assistance Needed

About the issue. I am willing to do some extra work to plug in `core::time::Duration`. But I wanted to speak to a human first, as I saw some code within `crates/mirror-mirror/src/foreign_impls/via_scalar.rs` related to duration and I didn't want to break anything.

I'm also not 100% sure how the `serde`/`glam`/etc. compatibility or what tests should/should-not be added.
